### PR TITLE
add support for SLIP39

### DIFF
--- a/src/embit/slip39.py
+++ b/src/embit/slip39.py
@@ -1,0 +1,1399 @@
+import hmac
+import random
+import sys
+
+if sys.implementation.name == "micropython":
+    import hashlib
+    from micropython import const
+else:
+    from .util import hashlib, const
+
+
+from .bip39 import mnemonic_from_bytes, mnemonic_to_bytes
+
+
+# functions for SLIP39 checksum
+def rs1024_polymod(values):
+    GEN = [
+        0xE0E040,
+        0x1C1C080,
+        0x3838100,
+        0x7070200,
+        0xE0E0009,
+        0x1C0C2412,
+        0x38086C24,
+        0x3090FC48,
+        0x21B1F890,
+        0x3F3F120,
+    ]
+    chk = 1
+    for v in values:
+        b = chk >> 20
+        chk = (chk & 0xFFFFF) << 10 ^ v
+        for i in range(10):
+            chk ^= GEN[i] if ((b >> i) & 1) else 0
+    return chk
+
+
+def rs1024_verify_checksum(cs, data):
+    return rs1024_polymod([x for x in cs] + data) == 1
+
+
+def rs1024_create_checksum(cs, data):
+    values = [x for x in cs] + data
+    polymod = rs1024_polymod(values + [0, 0, 0]) ^ 1
+    return [(polymod >> 10 * (2 - i)) & 1023 for i in range(3)]
+
+
+# function for encryption/decryption
+def _crypt(payload, id, exponent, passphrase, indices):
+    if len(payload) % 2:
+        raise ValueError("payload should be an even number of bytes")
+    else:
+        half = len(payload) // 2
+    left = payload[:half]
+    right = payload[half:]
+    salt = b"shamir" + id.to_bytes(2, "big")
+    for i in indices:
+        f = hashlib.pbkdf2_hmac_sha256(
+            i + passphrase,
+            salt + right,
+            2500 << exponent,
+            half,
+        )
+        left, right = right, bytes(x ^ y for x, y in zip(left, f))
+    return right + left
+
+
+class Share:
+    def __init__(
+        self,
+        share_bit_length,
+        id,
+        exponent,
+        group_index,
+        group_threshold,
+        group_count,
+        member_index,
+        member_threshold,
+        value,
+    ):
+        self.share_bit_length = share_bit_length
+        self.id = id
+        self.exponent = exponent
+        self.group_index = group_index
+        if group_index < 0 or group_index > 15:
+            raise ValueError(
+                "Group index should be between 0 and 15 inclusive"
+            )
+        self.group_threshold = group_threshold
+        if group_threshold < 1 or group_threshold > group_count:
+            raise ValueError(
+                "Group threshold should be between 1 and %d inclusive" % group_count
+            )
+        self.group_count = group_count
+        if group_count < 1 or group_count > 16:
+            raise ValueError(
+                "Group count should be between 1 and 16 inclusive"
+            )
+        self.member_index = member_index
+        if member_index < 0 or member_index > 15:
+            raise ValueError(
+                "Member index should be between 0 and 15 inclusive"
+            )
+        self.member_threshold = member_threshold
+        if member_threshold < 1 or member_threshold > 16:
+            raise ValueError(
+                "Member threshold should be between 1 and 16 inclusive"
+            )
+        self.value = value
+        self.bytes = value.to_bytes(share_bit_length // 8, "big")
+
+    @classmethod
+    def parse(cls, mnemonic):
+        # convert mnemonic into bits
+        words = mnemonic.split()
+        indices = [SLIP39_WORDS.index(word) for word in words]
+        if not rs1024_verify_checksum(b"shamir", indices):
+            raise ValueError("Invalid Checksum")
+        id = (indices[0] << 5) | (indices[1] >> 5)
+        exponent = indices[1] & 31
+        group_index = indices[2] >> 6
+        group_threshold = ((indices[2] >> 2) & 15) + 1
+        group_count = (((indices[2] & 3) << 2) | (indices[3] >> 8)) + 1
+        member_index = (indices[3] >> 4) & 15
+        member_threshold = (indices[3] & 15) + 1
+        value = 0
+        for index in indices[4:-3]:
+            value = (value << 10) | index
+        share_bit_length = (len(indices) - 7) * 10 // 16 * 16
+        if value >> share_bit_length != 0:
+            raise SyntaxError("Share not 0-padded properly")
+        if share_bit_length < 128:
+            raise ValueError("not enough bits")
+        return cls(
+            share_bit_length,
+            id,
+            exponent,
+            group_index,
+            group_threshold,
+            group_count,
+            member_index,
+            member_threshold,
+            value,
+        )
+
+    def mnemonic(self):
+        all_bits = (self.id << 5) | self.exponent
+        all_bits <<= 4
+        all_bits |= self.group_index
+        all_bits <<= 4
+        all_bits |= self.group_threshold - 1
+        all_bits <<= 4
+        all_bits |= self.group_count - 1
+        all_bits <<= 4
+        all_bits |= self.member_index
+        all_bits <<= 4
+        all_bits |= self.member_threshold - 1
+        padding = 10 - self.share_bit_length % 10
+        all_bits <<= padding + self.share_bit_length
+        all_bits |= self.value
+        num_words = 4 + (padding + self.share_bit_length) // 10
+        indices = [
+            (all_bits >> 10 * (num_words - i - 1)) & 1023 for i in range(num_words)
+        ]
+        checksum = rs1024_create_checksum(b"shamir", indices)
+        return " ".join([SLIP39_WORDS[index] for index in indices + checksum])
+
+
+class ShareSet:
+    @classmethod
+    def _load(cls):
+        """Pre-computes the exponent/log for LaGrange calculation"""
+        cls.exp = [0] * 255
+        cls.log2 = [0] * 256
+        cur = 1
+        for i in range(255):
+            cls.exp[i] = cur
+            cls.log2[cur] = i
+            cur = (cur << 1) ^ cur
+            if cur > 255:
+                cur ^= 0x11B
+
+    def __init__(self, shares):
+        self.shares = shares
+        if len(shares) > 1:
+            # check that the identifiers are the same
+            ids = {s.id for s in shares}
+            if len(ids) != 1:
+                raise TypeError("Shares are from different secrets")
+            # check that the exponents are the same
+            exponents = {s.exponent for s in shares}
+            if len(exponents) != 1:
+                raise TypeError("Shares should have the same exponent")
+            # check that the k-of-n is the same
+            k = {s.group_threshold for s in shares}
+            if len(k) != 1:
+                raise ValueError("K of K-of-N should be the same")
+            n = {s.group_count for s in shares}
+            if len(n) != 1:
+                raise ValueError("N of K-of-N should be the same")
+            if k.pop() > n.pop():
+                raise ValueError("K > N in K-of-N")
+            # check that the share lengths are the same
+            lengths = {s.share_bit_length for s in shares}
+            if len(lengths) != 1:
+                raise ValueError("all shares should have the same length")
+            # check that the x coordinates are unique
+            xs = {(s.group_index, s.member_index) for s in shares}
+            if len(xs) != len(shares):
+                raise ValueError("Share indices should be unique")
+        self.id = shares[0].id
+        self.salt = b"shamir" + self.id.to_bytes(2, "big")
+        self.exponent = shares[0].exponent
+        self.group_threshold = shares[0].group_threshold
+        self.group_count = shares[0].group_count
+        self.share_bit_length = shares[0].share_bit_length
+
+    def decrypt(self, secret, passphrase=b""):
+        # decryption does the reverse of encryption
+        indices = (b"\x03", b"\x02", b"\x01", b"\x00")
+        return _crypt(secret, self.id, self.exponent, passphrase, indices)
+
+    @classmethod
+    def encrypt(cls, payload, id, exponent, passphrase=b""):
+        # encryption goes from 0 to 3 in bytes
+        indices = (b"\x00", b"\x01", b"\x02", b"\x03")
+        return _crypt(payload, id, exponent, passphrase, indices)
+
+    @classmethod
+    def interpolate(cls, x, share_data):
+        """Gets the y value at a particular x"""
+        # we're using the LaGrange formula
+        # https://github.com/satoshilabs/slips/blob/master/slip-0039/lagrange.png
+        # the numerator of the multiplication part is what we're pre-computing
+        # (x - x_i) 0<=i<=m where x_i is each x in the share
+        # we don't store this, but the log of this
+        # and exponentiate later
+        log_product = sum(cls.log2[share_x ^ x] for share_x, _ in share_data)
+        # the y value that we want is stored in result
+        result = bytes(len(share_data[0][1]))
+        for share_x, share_bytes in share_data:
+            # we have to subtract the current x - x_i since
+            # the formula is for j where j != i
+            log_numerator = log_product - cls.log2[share_x ^ x]
+            # the denominator we can just sum because we cheated and made
+            # log(0) = 0 which will happen when i = j
+            log_denominator = sum(
+                cls.log2[share_x ^ other_x] for other_x, _ in share_data
+            )
+            log = (log_numerator - log_denominator) % 255
+            result = bytes(
+                c ^ (cls.exp[(cls.log2[y] + log) % 255] if y > 0 else 0)
+                for y, c in zip(share_bytes, result)
+            )
+        return result
+
+    @classmethod
+    def digest(cls, r, shared_secret):
+        return hmac.new(r, shared_secret, "sha256").digest()[:4]
+
+    @classmethod
+    def recover_secret(cls, share_data):
+        """return a shared secret from a list of shares"""
+        shared_secret = cls.interpolate(255, share_data)
+        digest_share = cls.interpolate(254, share_data)
+        digest = digest_share[:4]
+        random = digest_share[4:]
+        if digest != cls.digest(random, shared_secret):
+            raise ValueError("Digest does not match secret")
+        return shared_secret
+
+    def recover(self, passphrase=b""):
+        """recover a shared secret from the current group of shares"""
+        # group by group index
+        groups = [[] for _ in range(self.group_count)]
+        for share in self.shares:
+            groups[share.group_index].append(share)
+        # gather share data of each group
+        share_data = []
+        for i, group in enumerate(groups):
+            if len(group) == 0:
+                continue
+            member_thresholds = {share.member_threshold for share in group}
+            if len(member_thresholds) != 1:
+                raise ValueError("Member thresholds should be the same within a group")
+            member_threshold = member_thresholds.pop()
+            if member_threshold == 1:
+                share_data.append((i, group[0].bytes))
+            elif member_threshold > len(group):
+                raise ValueError("Not enough shares")
+            else:
+                member_data = [(share.member_index, share.bytes) for share in group]
+                share_data.append((i, self.recover_secret(member_data)))
+        if self.group_threshold == 1:
+            return self.decrypt(share_data[0][1], passphrase)
+        elif self.group_threshold > len(share_data):
+            raise ValueError("Not enough shares")
+        shared_secret = self.recover_secret(share_data)
+        return self.decrypt(shared_secret, passphrase)
+
+    @classmethod
+    def split_secret(cls, secret, k, n, randint=random.randint):
+        """Split secret into k-of-n shares"""
+        if n < 1:
+            raise ValueError("N is too small, must be at least 1")
+        if n > 16:
+            raise ValueError("N is too big, must be 16 or less")
+        if k < 1:
+            raise ValueError("K is too small, must be at least 1")
+        if k > n:
+            raise ValueError("K is too big, K <= N")
+        num_bytes = len(secret)
+        if num_bytes not in (16, 32):
+            raise ValueError("secret should be 128 bits or 256 bits")
+        if k == 1:
+            return [(0, secret)]
+        else:
+            r = bytes(randint(0, 255) for _ in range(num_bytes - 4))
+            digest = cls.digest(r, secret)
+            digest_share = digest + r
+            share_data = [
+                (i, bytes(randint(0, 255) for _ in range(num_bytes))) for i in range(k - 2)
+            ]
+            more_data = share_data.copy()
+            share_data.append((254, digest_share))
+            share_data.append((255, secret))
+            for i in range(k - 2, n):
+                more_data.append((i, cls.interpolate(i, share_data)))
+        return more_data
+
+    @classmethod
+    def generate_shares(cls, mnemonic, k, n, passphrase=b"", exponent=0, randint=random.randint):
+        """Takes a BIP39 mnemonic along with k, n, passphrase and exponent.
+        Returns a list of SLIP39 mnemonics, any k of of which, along with the passphrase, recover the secret"""
+        # convert mnemonic to a shared secret
+        secret = mnemonic_to_bytes(mnemonic)
+        num_bits = len(secret) * 8
+        if num_bits not in (128, 256):
+            raise ValueError("mnemonic must be 12 or 24 words")
+        # generate id
+        id = randint(0, 32767)
+        # encrypt secret with passphrase
+        encrypted = cls.encrypt(secret, id, exponent, passphrase)
+        # split encrypted payload and create shares
+        shares = []
+        data = cls.split_secret(encrypted, k, n)
+        for group_index, share_bytes in data:
+            share = Share(
+                share_bit_length=num_bits,
+                id=id,
+                exponent=exponent,
+                group_index=group_index,
+                group_threshold=k,
+                group_count=n,
+                member_index=0,
+                member_threshold=1,
+                value=int.from_bytes(share_bytes, "big"),
+            )
+            shares.append(share.mnemonic())
+        return shares
+
+    @classmethod
+    def recover_mnemonic(cls, share_mnemonics, passphrase=b""):
+        """Recovers the BIP39 mnemonic from a bunch of SLIP39 mnemonics"""
+        shares = [Share.parse(m) for m in share_mnemonics]
+        share_set = ShareSet(shares)
+        secret = share_set.recover(passphrase)
+        return mnemonic_from_bytes(secret)
+
+
+ShareSet._load()
+
+
+SLIP39_WORDS = [
+    "academic",
+    "acid",
+    "acne",
+    "acquire",
+    "acrobat",
+    "activity",
+    "actress",
+    "adapt",
+    "adequate",
+    "adjust",
+    "admit",
+    "adorn",
+    "adult",
+    "advance",
+    "advocate",
+    "afraid",
+    "again",
+    "agency",
+    "agree",
+    "aide",
+    "aircraft",
+    "airline",
+    "airport",
+    "ajar",
+    "alarm",
+    "album",
+    "alcohol",
+    "alien",
+    "alive",
+    "alpha",
+    "already",
+    "alto",
+    "aluminum",
+    "always",
+    "amazing",
+    "ambition",
+    "amount",
+    "amuse",
+    "analysis",
+    "anatomy",
+    "ancestor",
+    "ancient",
+    "angel",
+    "angry",
+    "animal",
+    "answer",
+    "antenna",
+    "anxiety",
+    "apart",
+    "aquatic",
+    "arcade",
+    "arena",
+    "argue",
+    "armed",
+    "artist",
+    "artwork",
+    "aspect",
+    "auction",
+    "august",
+    "aunt",
+    "average",
+    "aviation",
+    "avoid",
+    "award",
+    "away",
+    "axis",
+    "axle",
+    "beam",
+    "beard",
+    "beaver",
+    "become",
+    "bedroom",
+    "behavior",
+    "being",
+    "believe",
+    "belong",
+    "benefit",
+    "best",
+    "beyond",
+    "bike",
+    "biology",
+    "birthday",
+    "bishop",
+    "black",
+    "blanket",
+    "blessing",
+    "blimp",
+    "blind",
+    "blue",
+    "body",
+    "bolt",
+    "boring",
+    "born",
+    "both",
+    "boundary",
+    "bracelet",
+    "branch",
+    "brave",
+    "breathe",
+    "briefing",
+    "broken",
+    "brother",
+    "browser",
+    "bucket",
+    "budget",
+    "building",
+    "bulb",
+    "bulge",
+    "bumpy",
+    "bundle",
+    "burden",
+    "burning",
+    "busy",
+    "buyer",
+    "cage",
+    "calcium",
+    "camera",
+    "campus",
+    "canyon",
+    "capacity",
+    "capital",
+    "capture",
+    "carbon",
+    "cards",
+    "careful",
+    "cargo",
+    "carpet",
+    "carve",
+    "category",
+    "cause",
+    "ceiling",
+    "center",
+    "ceramic",
+    "champion",
+    "change",
+    "charity",
+    "check",
+    "chemical",
+    "chest",
+    "chew",
+    "chubby",
+    "cinema",
+    "civil",
+    "class",
+    "clay",
+    "cleanup",
+    "client",
+    "climate",
+    "clinic",
+    "clock",
+    "clogs",
+    "closet",
+    "clothes",
+    "club",
+    "cluster",
+    "coal",
+    "coastal",
+    "coding",
+    "column",
+    "company",
+    "corner",
+    "costume",
+    "counter",
+    "course",
+    "cover",
+    "cowboy",
+    "cradle",
+    "craft",
+    "crazy",
+    "credit",
+    "cricket",
+    "criminal",
+    "crisis",
+    "critical",
+    "crowd",
+    "crucial",
+    "crunch",
+    "crush",
+    "crystal",
+    "cubic",
+    "cultural",
+    "curious",
+    "curly",
+    "custody",
+    "cylinder",
+    "daisy",
+    "damage",
+    "dance",
+    "darkness",
+    "database",
+    "daughter",
+    "deadline",
+    "deal",
+    "debris",
+    "debut",
+    "decent",
+    "decision",
+    "declare",
+    "decorate",
+    "decrease",
+    "deliver",
+    "demand",
+    "density",
+    "deny",
+    "depart",
+    "depend",
+    "depict",
+    "deploy",
+    "describe",
+    "desert",
+    "desire",
+    "desktop",
+    "destroy",
+    "detailed",
+    "detect",
+    "device",
+    "devote",
+    "diagnose",
+    "dictate",
+    "diet",
+    "dilemma",
+    "diminish",
+    "dining",
+    "diploma",
+    "disaster",
+    "discuss",
+    "disease",
+    "dish",
+    "dismiss",
+    "display",
+    "distance",
+    "dive",
+    "divorce",
+    "document",
+    "domain",
+    "domestic",
+    "dominant",
+    "dough",
+    "downtown",
+    "dragon",
+    "dramatic",
+    "dream",
+    "dress",
+    "drift",
+    "drink",
+    "drove",
+    "drug",
+    "dryer",
+    "duckling",
+    "duke",
+    "duration",
+    "dwarf",
+    "dynamic",
+    "early",
+    "earth",
+    "easel",
+    "easy",
+    "echo",
+    "eclipse",
+    "ecology",
+    "edge",
+    "editor",
+    "educate",
+    "either",
+    "elbow",
+    "elder",
+    "election",
+    "elegant",
+    "element",
+    "elephant",
+    "elevator",
+    "elite",
+    "else",
+    "email",
+    "emerald",
+    "emission",
+    "emperor",
+    "emphasis",
+    "employer",
+    "empty",
+    "ending",
+    "endless",
+    "endorse",
+    "enemy",
+    "energy",
+    "enforce",
+    "engage",
+    "enjoy",
+    "enlarge",
+    "entrance",
+    "envelope",
+    "envy",
+    "epidemic",
+    "episode",
+    "equation",
+    "equip",
+    "eraser",
+    "erode",
+    "escape",
+    "estate",
+    "estimate",
+    "evaluate",
+    "evening",
+    "evidence",
+    "evil",
+    "evoke",
+    "exact",
+    "example",
+    "exceed",
+    "exchange",
+    "exclude",
+    "excuse",
+    "execute",
+    "exercise",
+    "exhaust",
+    "exotic",
+    "expand",
+    "expect",
+    "explain",
+    "express",
+    "extend",
+    "extra",
+    "eyebrow",
+    "facility",
+    "fact",
+    "failure",
+    "faint",
+    "fake",
+    "false",
+    "family",
+    "famous",
+    "fancy",
+    "fangs",
+    "fantasy",
+    "fatal",
+    "fatigue",
+    "favorite",
+    "fawn",
+    "fiber",
+    "fiction",
+    "filter",
+    "finance",
+    "findings",
+    "finger",
+    "firefly",
+    "firm",
+    "fiscal",
+    "fishing",
+    "fitness",
+    "flame",
+    "flash",
+    "flavor",
+    "flea",
+    "flexible",
+    "flip",
+    "float",
+    "floral",
+    "fluff",
+    "focus",
+    "forbid",
+    "force",
+    "forecast",
+    "forget",
+    "formal",
+    "fortune",
+    "forward",
+    "founder",
+    "fraction",
+    "fragment",
+    "frequent",
+    "freshman",
+    "friar",
+    "fridge",
+    "friendly",
+    "frost",
+    "froth",
+    "frozen",
+    "fumes",
+    "funding",
+    "furl",
+    "fused",
+    "galaxy",
+    "game",
+    "garbage",
+    "garden",
+    "garlic",
+    "gasoline",
+    "gather",
+    "general",
+    "genius",
+    "genre",
+    "genuine",
+    "geology",
+    "gesture",
+    "glad",
+    "glance",
+    "glasses",
+    "glen",
+    "glimpse",
+    "goat",
+    "golden",
+    "graduate",
+    "grant",
+    "grasp",
+    "gravity",
+    "gray",
+    "greatest",
+    "grief",
+    "grill",
+    "grin",
+    "grocery",
+    "gross",
+    "group",
+    "grownup",
+    "grumpy",
+    "guard",
+    "guest",
+    "guilt",
+    "guitar",
+    "gums",
+    "hairy",
+    "hamster",
+    "hand",
+    "hanger",
+    "harvest",
+    "have",
+    "havoc",
+    "hawk",
+    "hazard",
+    "headset",
+    "health",
+    "hearing",
+    "heat",
+    "helpful",
+    "herald",
+    "herd",
+    "hesitate",
+    "hobo",
+    "holiday",
+    "holy",
+    "home",
+    "hormone",
+    "hospital",
+    "hour",
+    "huge",
+    "human",
+    "humidity",
+    "hunting",
+    "husband",
+    "hush",
+    "husky",
+    "hybrid",
+    "idea",
+    "identify",
+    "idle",
+    "image",
+    "impact",
+    "imply",
+    "improve",
+    "impulse",
+    "include",
+    "income",
+    "increase",
+    "index",
+    "indicate",
+    "industry",
+    "infant",
+    "inform",
+    "inherit",
+    "injury",
+    "inmate",
+    "insect",
+    "inside",
+    "install",
+    "intend",
+    "intimate",
+    "invasion",
+    "involve",
+    "iris",
+    "island",
+    "isolate",
+    "item",
+    "ivory",
+    "jacket",
+    "jerky",
+    "jewelry",
+    "join",
+    "judicial",
+    "juice",
+    "jump",
+    "junction",
+    "junior",
+    "junk",
+    "jury",
+    "justice",
+    "kernel",
+    "keyboard",
+    "kidney",
+    "kind",
+    "kitchen",
+    "knife",
+    "knit",
+    "laden",
+    "ladle",
+    "ladybug",
+    "lair",
+    "lamp",
+    "language",
+    "large",
+    "laser",
+    "laundry",
+    "lawsuit",
+    "leader",
+    "leaf",
+    "learn",
+    "leaves",
+    "lecture",
+    "legal",
+    "legend",
+    "legs",
+    "lend",
+    "length",
+    "level",
+    "liberty",
+    "library",
+    "license",
+    "lift",
+    "likely",
+    "lilac",
+    "lily",
+    "lips",
+    "liquid",
+    "listen",
+    "literary",
+    "living",
+    "lizard",
+    "loan",
+    "lobe",
+    "location",
+    "losing",
+    "loud",
+    "loyalty",
+    "luck",
+    "lunar",
+    "lunch",
+    "lungs",
+    "luxury",
+    "lying",
+    "lyrics",
+    "machine",
+    "magazine",
+    "maiden",
+    "mailman",
+    "main",
+    "makeup",
+    "making",
+    "mama",
+    "manager",
+    "mandate",
+    "mansion",
+    "manual",
+    "marathon",
+    "march",
+    "market",
+    "marvel",
+    "mason",
+    "material",
+    "math",
+    "maximum",
+    "mayor",
+    "meaning",
+    "medal",
+    "medical",
+    "member",
+    "memory",
+    "mental",
+    "merchant",
+    "merit",
+    "method",
+    "metric",
+    "midst",
+    "mild",
+    "military",
+    "mineral",
+    "minister",
+    "miracle",
+    "mixed",
+    "mixture",
+    "mobile",
+    "modern",
+    "modify",
+    "moisture",
+    "moment",
+    "morning",
+    "mortgage",
+    "mother",
+    "mountain",
+    "mouse",
+    "move",
+    "much",
+    "mule",
+    "multiple",
+    "muscle",
+    "museum",
+    "music",
+    "mustang",
+    "nail",
+    "national",
+    "necklace",
+    "negative",
+    "nervous",
+    "network",
+    "news",
+    "nuclear",
+    "numb",
+    "numerous",
+    "nylon",
+    "oasis",
+    "obesity",
+    "object",
+    "observe",
+    "obtain",
+    "ocean",
+    "often",
+    "olympic",
+    "omit",
+    "oral",
+    "orange",
+    "orbit",
+    "order",
+    "ordinary",
+    "organize",
+    "ounce",
+    "oven",
+    "overall",
+    "owner",
+    "paces",
+    "pacific",
+    "package",
+    "paid",
+    "painting",
+    "pajamas",
+    "pancake",
+    "pants",
+    "papa",
+    "paper",
+    "parcel",
+    "parking",
+    "party",
+    "patent",
+    "patrol",
+    "payment",
+    "payroll",
+    "peaceful",
+    "peanut",
+    "peasant",
+    "pecan",
+    "penalty",
+    "pencil",
+    "percent",
+    "perfect",
+    "permit",
+    "petition",
+    "phantom",
+    "pharmacy",
+    "photo",
+    "phrase",
+    "physics",
+    "pickup",
+    "picture",
+    "piece",
+    "pile",
+    "pink",
+    "pipeline",
+    "pistol",
+    "pitch",
+    "plains",
+    "plan",
+    "plastic",
+    "platform",
+    "playoff",
+    "pleasure",
+    "plot",
+    "plunge",
+    "practice",
+    "prayer",
+    "preach",
+    "predator",
+    "pregnant",
+    "premium",
+    "prepare",
+    "presence",
+    "prevent",
+    "priest",
+    "primary",
+    "priority",
+    "prisoner",
+    "privacy",
+    "prize",
+    "problem",
+    "process",
+    "profile",
+    "program",
+    "promise",
+    "prospect",
+    "provide",
+    "prune",
+    "public",
+    "pulse",
+    "pumps",
+    "punish",
+    "puny",
+    "pupal",
+    "purchase",
+    "purple",
+    "python",
+    "quantity",
+    "quarter",
+    "quick",
+    "quiet",
+    "race",
+    "racism",
+    "radar",
+    "railroad",
+    "rainbow",
+    "raisin",
+    "random",
+    "ranked",
+    "rapids",
+    "raspy",
+    "reaction",
+    "realize",
+    "rebound",
+    "rebuild",
+    "recall",
+    "receiver",
+    "recover",
+    "regret",
+    "regular",
+    "reject",
+    "relate",
+    "remember",
+    "remind",
+    "remove",
+    "render",
+    "repair",
+    "repeat",
+    "replace",
+    "require",
+    "rescue",
+    "research",
+    "resident",
+    "response",
+    "result",
+    "retailer",
+    "retreat",
+    "reunion",
+    "revenue",
+    "review",
+    "reward",
+    "rhyme",
+    "rhythm",
+    "rich",
+    "rival",
+    "river",
+    "robin",
+    "rocky",
+    "romantic",
+    "romp",
+    "roster",
+    "round",
+    "royal",
+    "ruin",
+    "ruler",
+    "rumor",
+    "sack",
+    "safari",
+    "salary",
+    "salon",
+    "salt",
+    "satisfy",
+    "satoshi",
+    "saver",
+    "says",
+    "scandal",
+    "scared",
+    "scatter",
+    "scene",
+    "scholar",
+    "science",
+    "scout",
+    "scramble",
+    "screw",
+    "script",
+    "scroll",
+    "seafood",
+    "season",
+    "secret",
+    "security",
+    "segment",
+    "senior",
+    "shadow",
+    "shaft",
+    "shame",
+    "shaped",
+    "sharp",
+    "shelter",
+    "sheriff",
+    "short",
+    "should",
+    "shrimp",
+    "sidewalk",
+    "silent",
+    "silver",
+    "similar",
+    "simple",
+    "single",
+    "sister",
+    "skin",
+    "skunk",
+    "slap",
+    "slavery",
+    "sled",
+    "slice",
+    "slim",
+    "slow",
+    "slush",
+    "smart",
+    "smear",
+    "smell",
+    "smirk",
+    "smith",
+    "smoking",
+    "smug",
+    "snake",
+    "snapshot",
+    "sniff",
+    "society",
+    "software",
+    "soldier",
+    "solution",
+    "soul",
+    "source",
+    "space",
+    "spark",
+    "speak",
+    "species",
+    "spelling",
+    "spend",
+    "spew",
+    "spider",
+    "spill",
+    "spine",
+    "spirit",
+    "spit",
+    "spray",
+    "sprinkle",
+    "square",
+    "squeeze",
+    "stadium",
+    "staff",
+    "standard",
+    "starting",
+    "station",
+    "stay",
+    "steady",
+    "step",
+    "stick",
+    "stilt",
+    "story",
+    "strategy",
+    "strike",
+    "style",
+    "subject",
+    "submit",
+    "sugar",
+    "suitable",
+    "sunlight",
+    "superior",
+    "surface",
+    "surprise",
+    "survive",
+    "sweater",
+    "swimming",
+    "swing",
+    "switch",
+    "symbolic",
+    "sympathy",
+    "syndrome",
+    "system",
+    "tackle",
+    "tactics",
+    "tadpole",
+    "talent",
+    "task",
+    "taste",
+    "taught",
+    "taxi",
+    "teacher",
+    "teammate",
+    "teaspoon",
+    "temple",
+    "tenant",
+    "tendency",
+    "tension",
+    "terminal",
+    "testify",
+    "texture",
+    "thank",
+    "that",
+    "theater",
+    "theory",
+    "therapy",
+    "thorn",
+    "threaten",
+    "thumb",
+    "thunder",
+    "ticket",
+    "tidy",
+    "timber",
+    "timely",
+    "ting",
+    "tofu",
+    "together",
+    "tolerate",
+    "total",
+    "toxic",
+    "tracks",
+    "traffic",
+    "training",
+    "transfer",
+    "trash",
+    "traveler",
+    "treat",
+    "trend",
+    "trial",
+    "tricycle",
+    "trip",
+    "triumph",
+    "trouble",
+    "true",
+    "trust",
+    "twice",
+    "twin",
+    "type",
+    "typical",
+    "ugly",
+    "ultimate",
+    "umbrella",
+    "uncover",
+    "undergo",
+    "unfair",
+    "unfold",
+    "unhappy",
+    "union",
+    "universe",
+    "unkind",
+    "unknown",
+    "unusual",
+    "unwrap",
+    "upgrade",
+    "upstairs",
+    "username",
+    "usher",
+    "usual",
+    "valid",
+    "valuable",
+    "vampire",
+    "vanish",
+    "various",
+    "vegan",
+    "velvet",
+    "venture",
+    "verdict",
+    "verify",
+    "very",
+    "veteran",
+    "vexed",
+    "victim",
+    "video",
+    "view",
+    "vintage",
+    "violence",
+    "viral",
+    "visitor",
+    "visual",
+    "vitamins",
+    "vocal",
+    "voice",
+    "volume",
+    "voter",
+    "voting",
+    "walnut",
+    "warmth",
+    "warn",
+    "watch",
+    "wavy",
+    "wealthy",
+    "weapon",
+    "webcam",
+    "welcome",
+    "welfare",
+    "western",
+    "width",
+    "wildlife",
+    "window",
+    "wine",
+    "wireless",
+    "wisdom",
+    "withdraw",
+    "wits",
+    "wolf",
+    "woman",
+    "work",
+    "worthy",
+    "wrap",
+    "wrist",
+    "writing",
+    "wrote",
+    "year",
+    "yelp",
+    "yield",
+    "yoga",
+    "zero",
+]

--- a/src/embit/util/hashlib.py
+++ b/src/embit/util/hashlib.py
@@ -1,6 +1,6 @@
 try:
-    from hashlib import hmac_sha512, pbkdf2_hmac_sha512, ripemd160
+    from hashlib import hmac_sha512, pbkdf2_hmac_sha512, ripemd160, pbkdf2_hmac_sha256
 except:
-    from .pyhashlib import hmac_sha512, pbkdf2_hmac_sha512, ripemd160
+    from .pyhashlib import hmac_sha512, pbkdf2_hmac_sha512, ripemd160, pbkdf2_hmac_sha256
 
 from hashlib import *

--- a/src/embit/util/pyhashlib.py
+++ b/src/embit/util/pyhashlib.py
@@ -1,12 +1,13 @@
 import hmac
 import hashlib
 
-# https://en.wikipedia.org/wiki/PBKDF2
-def pbkdf2_hmac_sha512(password, salt, iterations: int, bytes_to_read: int):
-    # xor two arrays
-    def binxor(a, b):
-        return bytes([x ^ y for (x, y) in zip(a, b)])
+# xor two arrays
+def binxor(a, b):
+    return bytes([x ^ y for (x, y) in zip(a, b)])
 
+
+# https://en.wikipedia.org/wiki/PBKDF2
+def pbkdf2_hmac(password, salt, iterations: int, bytes_to_read: int, digestmod):
     # convert to bytes
     if isinstance(password, str):
         password = password.encode("utf-8")
@@ -15,15 +16,23 @@ def pbkdf2_hmac_sha512(password, salt, iterations: int, bytes_to_read: int):
     # result
     r = b""
     for i in range(1, bytes_to_read // 64 + 1 + int(bool(bytes_to_read % 64))):
-        U = hmac.new(
-            password, salt + i.to_bytes(4, "big"), digestmod=hashlib.sha512
+        current = hmac.new(
+            password, salt + i.to_bytes(4, "big"), digestmod=digestmod
         ).digest()
-        result = U
+        result = current
         for j in range(2, 1 + iterations):
-            U = hmac.new(password, U, digestmod=hashlib.sha512).digest()
-            result = binxor(result, U)
+            current = hmac.new(password, current, digestmod=digestmod).digest()
+            result = binxor(result, current)
         r += result
     return r[:bytes_to_read]
+
+
+def pbkdf2_hmac_sha512(password, salt, iterations: int, bytes_to_read: int):
+    return pbkdf2_hmac(password, salt, iterations, bytes_to_read, hashlib.sha512)
+
+
+def pbkdf2_hmac_sha256(password, salt, iterations: int, bytes_to_read: int):
+    return pbkdf2_hmac(password, salt, iterations, bytes_to_read, hashlib.sha256)
 
 
 def ripemd160(*args, **kwargs):

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -5,6 +5,7 @@ from .test_bech32 import *
 from .test_bip32 import *
 from .test_psbt import *
 from .test_bip39 import *
+from .test_slip39 import *
 from .test_descriptor import *
 from .test_liquid import *
 

--- a/tests/tests/test_slip39.py
+++ b/tests/tests/test_slip39.py
@@ -1,0 +1,366 @@
+# BIP32 test vectors adapted from the reference implementation:
+# https://github.com/trezor/python-mnemonic/blob/master/test_mnemonic.py
+
+from binascii import hexlify, unhexlify
+from embit.bip32 import HDKey
+from embit.slip39 import (
+    Share,
+    ShareSet,
+)
+from unittest import TestCase
+
+
+class Slip39Test(TestCase):
+    def test_share_errors(self):
+        test_cases = [
+            [
+                "2. Mnemonic with invalid checksum (128 bits)",
+                [
+                    "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision kidney"
+                ],
+                ValueError,
+            ],
+            [
+                "3. Mnemonic with invalid padding (128 bits)",
+                [
+                    "duckling enlarge academic academic email result length solution fridge kidney coal piece deal husband erode duke ajar music cargo fitness"
+                ],
+                SyntaxError,
+            ],
+            [
+                "5. Basic sharing 2-of-3 (128 bits)",
+                [
+                    "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed"
+                ],
+                ValueError,
+            ],
+            [
+                "6. Mnemonics with different identifiers (128 bits)",
+                [
+                    "adequate smoking academic acid debut wine petition glen cluster slow rhyme slow simple epidemic rumor junk tracks treat olympic tolerate",
+                    "adequate stay academic agency agency formal party ting frequent learn upstairs remember smear leaf damage anatomy ladle market hush corner",
+                ],
+                TypeError,
+            ],
+            [
+                "7. Mnemonics with different iteration exponents (128 bits)",
+                [
+                    "peasant leaves academic acid desert exact olympic math alive axle trial tackle drug deny decent smear dominant desert bucket remind",
+                    "peasant leader academic agency cultural blessing percent network envelope medal junk primary human pumps jacket fragment payroll ticket evoke voice",
+                ],
+                TypeError,
+            ],
+            [
+                "8. Mnemonics with mismatching group thresholds (128 bits)",
+                [
+                    "liberty category beard echo animal fawn temple briefing math username various wolf aviation fancy visual holy thunder yelp helpful payment",
+                    "liberty category beard email beyond should fancy romp founder easel pink holy hairy romp loyalty material victim owner toxic custody",
+                    "liberty category academic easy being hazard crush diminish oral lizard reaction cluster force dilemma deploy force club veteran expect photo",
+                ],
+                ValueError,
+            ],
+            [
+                "9. Mnemonics with mismatching group counts (128 bits)",
+                [
+                    "average senior academic leaf broken teacher expect surface hour capture obesity desire negative dynamic dominant pistol mineral mailman iris aide",
+                    "average senior academic agency curious pants blimp spew clothes slice script dress wrap firm shaft regular slavery negative theater roster",
+                ],
+                ValueError,
+            ],
+            [
+                "10. Mnemonics with greater group threshold than group counts (128 bits)",
+                [
+                    "music husband acrobat acid artist finance center either graduate swimming object bike medical clothes station aspect spider maiden bulb welcome",
+                    "music husband acrobat agency advance hunting bike corner density careful material civil evil tactics remind hawk discuss hobo voice rainbow",
+                    "music husband beard academic black tricycle clock mayor estimate level photo episode exclude ecology papa source amazing salt verify divorce",
+                ],
+                ValueError,
+            ],
+            [
+                "11. Mnemonics with duplicate member indices (128 bits)",
+                [
+                    "device stay academic always dive coal antenna adult black exceed stadium herald advance soldier busy dryer daughter evaluate minister laser",
+                    "device stay academic always dwarf afraid robin gravity crunch adjust soul branch walnut coastal dream costume scholar mortgage mountain pumps",
+                ],
+                ValueError,
+            ],
+            [
+                "12. Mnemonics with mismatching member thresholds (128 bits)",
+                [
+                    "hour painting academic academic device formal evoke guitar random modern justice filter withdraw trouble identify mailman insect general cover oven",
+                    "hour painting academic agency artist again daisy capital beaver fiber much enjoy suitable symbolic identify photo editor romp float echo",
+                ],
+                ValueError,
+            ],
+            [
+                "13. Mnemonics giving an invalid digest (128 bits)",
+                [
+                    "guilt walnut academic acid deliver remove equip listen vampire tactics nylon rhythm failure husband fatigue alive blind enemy teaspoon rebound",
+                    "guilt walnut academic agency brave hamster hobo declare herd taste alpha slim criminal mild arcade formal romp branch pink ambition",
+                ],
+                ValueError,
+            ],
+            [
+                "14. Insufficient number of groups (128 bits, case 1)",
+                [
+                    "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice"
+                ],
+                ValueError,
+            ],
+            [
+                "15. Insufficient number of groups (128 bits, case 2)",
+                [
+                    "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join",
+                    "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter",
+                ],
+                ValueError,
+            ],
+            [
+                "16. Threshold number of groups, but insufficient number of members in one group (128 bits)",
+                [
+                    "eraser senior decision shadow artist work morning estate greatest pipeline plan ting petition forget hormone flexible general goat admit surface",
+                    "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+                ],
+                ValueError,
+            ],
+            [
+                "21. Mnemonic with invalid checksum (256 bits)",
+                [
+                    "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect lunar"
+                ],
+                ValueError,
+            ],
+            [
+                "22. Mnemonic with invalid padding (256 bits)",
+                [
+                    "theory painting academic academic campus sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips facility obtain sister"
+                ],
+                SyntaxError,
+            ],
+            [
+                "24. Basic sharing 2-of-3 (256 bits)",
+                [
+                    "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap"
+                ],
+                ValueError,
+            ],
+            [
+                "25. Mnemonics with different identifiers (256 bits)",
+                [
+                    "smear husband academic acid deadline scene venture distance dive overall parking bracelet elevator justice echo burning oven chest duke nylon",
+                    "smear isolate academic agency alpha mandate decorate burden recover guard exercise fatal force syndrome fumes thank guest drift dramatic mule",
+                ],
+                TypeError,
+            ],
+            [
+                "26. Mnemonics with different iteration exponents (256 bits)",
+                [
+                    "finger trash academic acid average priority dish revenue academic hospital spirit western ocean fact calcium syndrome greatest plan losing dictate",
+                    "finger traffic academic agency building lilac deny paces subject threaten diploma eclipse window unknown health slim piece dragon focus smirk",
+                ],
+                TypeError,
+            ],
+            [
+                "27. Mnemonics with mismatching group thresholds (256 bits)",
+                [
+                    "flavor pink beard echo depart forbid retreat become frost helpful juice unwrap reunion credit math burning spine black capital lair",
+                    "flavor pink beard email diet teaspoon freshman identify document rebound cricket prune headset loyalty smell emission skin often square rebound",
+                    "flavor pink academic easy credit cage raisin crazy closet lobe mobile become drink human tactics valuable hand capture sympathy finger",
+                ],
+                ValueError,
+            ],
+            [
+                "28. Mnemonics with mismatching group counts (256 bits)",
+                [
+                    "column flea academic leaf debut extra surface slow timber husky lawsuit game behavior husky swimming already paper episode tricycle scroll",
+                    "column flea academic agency blessing garbage party software stadium verify silent umbrella therapy decorate chemical erode dramatic eclipse replace apart",
+                ],
+                ValueError,
+            ],
+            [
+                "29. Mnemonics with greater group threshold than group counts (256 bits)",
+                [
+                    "smirk pink acrobat acid auction wireless impulse spine sprinkle fortune clogs elbow guest hush loyalty crush dictate tracks airport talent",
+                    "smirk pink acrobat agency dwarf emperor ajar organize legs slice harvest plastic dynamic style mobile float bulb health coding credit",
+                    "smirk pink beard academic alto strategy carve shame language rapids ruin smart location spray training acquire eraser endorse submit peaceful",
+                ],
+                ValueError,
+            ],
+            [
+                "30. Mnemonics with duplicate member indices (256 bits)",
+                [
+                    "fishing recover academic always device craft trend snapshot gums skin downtown watch device sniff hour clock public maximum garlic born",
+                    "fishing recover academic always aircraft view software cradle fangs amazing package plastic evaluate intend penalty epidemic anatomy quarter cage apart",
+                ],
+                ValueError,
+            ],
+            [
+                "31. Mnemonics with mismatching member thresholds (256 bits)",
+                [
+                    "evoke garden academic academic answer wolf scandal modern warmth station devote emerald market physics surface formal amazing aquatic gesture medical",
+                    "evoke garden academic agency deal revenue knit reunion decrease magazine flexible company goat repair alarm military facility clogs aide mandate",
+                ],
+                ValueError,
+            ],
+            [
+                "32. Mnemonics giving an invalid digest (256 bits)",
+                [
+                    "river deal academic acid average forbid pistol peanut custody bike class aunt hairy merit valid flexible learn ajar very easel",
+                    "river deal academic agency camera amuse lungs numb isolate display smear piece traffic worthy year patrol crush fact fancy emission",
+                ],
+                ValueError,
+            ],
+            [
+                "33. Insufficient number of groups (256 bits, case 1)",
+                [
+                    "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium"
+                ],
+                ValueError,
+            ],
+            [
+                "34. Insufficient number of groups (256 bits, case 2)",
+                [
+                    "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+                    "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install",
+                ],
+                ValueError,
+            ],
+            [
+                "35. Threshold number of groups, but insufficient number of members in one group (256 bits)",
+                [
+                    "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club",
+                    "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+                ],
+                ValueError,
+            ],
+            [
+                "39. Mnemonic with insufficient length",
+                [
+                    "junk necklace academic academic acne isolate join hesitate lunar roster dough calcium chemical ladybug amount mobile glasses verify cylinder"
+                ],
+                ValueError,
+            ],
+            [
+                "40. Mnemonic with invalid master secret length",
+                [
+                    "fraction necklace academic academic award teammate mouse regular testify coding building member verdict purchase blind camera duration email prepare spirit quarter"
+                ],
+                SyntaxError,
+            ],
+        ]
+        for test_name, mnemonics, error in test_cases:
+            with self.assertRaises(error):
+                share_set = ShareSet([Share.parse(m) for m in mnemonics])
+                share_set.recover(b"TREZOR")
+
+    def test_recover(self):
+        test_cases = [
+            [
+                "1. Valid mnemonic without sharing (128 bits)",
+                [
+                    "duckling enlarge academic academic agency result length solution fridge kidney coal piece deal husband erode duke ajar critical decision keyboard"
+                ],
+                "bb54aac4b89dc868ba37d9cc21b2cece",
+            ],
+            [
+                "4. Basic sharing 2-of-3 (128 bits)",
+                [
+                    "shadow pistol academic always adequate wildlife fancy gross oasis cylinder mustang wrist rescue view short owner flip making coding armed",
+                    "shadow pistol academic acid actress prayer class unknown daughter sweater depict flip twice unkind craft early superior advocate guest smoking",
+                ],
+                "b43ceb7e57a0ea8766221624d01b0864",
+            ],
+            [
+                "17. Threshold number of groups and members in each group (128 bits, case 1)",
+                [
+                    "eraser senior decision roster beard treat identify grumpy salt index fake aviation theater cubic bike cause research dragon emphasis counter",
+                    "eraser senior ceramic snake clay various huge numb argue hesitate auction category timber browser greatest hanger petition script leaf pickup",
+                    "eraser senior ceramic shaft dynamic become junior wrist silver peasant force math alto coal amazing segment yelp velvet image paces",
+                    "eraser senior ceramic round column hawk trust auction smug shame alive greatest sheriff living perfect corner chest sled fumes adequate",
+                    "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing",
+                ],
+                "7c3397a292a5941682d7a4ae2d898d11",
+            ],
+            [
+                "18. Threshold number of groups and members in each group (128 bits, case 2)",
+                [
+                    "eraser senior decision smug corner ruin rescue cubic angel tackle skin skunk program roster trash rumor slush angel flea amazing",
+                    "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+                    "eraser senior decision scared cargo theory device idea deliver modify curly include pancake both news skin realize vitamins away join",
+                ],
+                "7c3397a292a5941682d7a4ae2d898d11",
+            ],
+            [
+                "19. Threshold number of groups and members in each group (128 bits, case 3)",
+                [
+                    "eraser senior beard romp adorn nuclear spill corner cradle style ancient family general leader ambition exchange unusual garlic promise voice",
+                    "eraser senior acrobat romp bishop medical gesture pumps secret alive ultimate quarter priest subject class dictate spew material endless market",
+                ],
+                "7c3397a292a5941682d7a4ae2d898d11",
+            ],
+            [
+                "20. Valid mnemonic without sharing (256 bits)",
+                [
+                    "theory painting academic academic armed sweater year military elder discuss acne wildlife boring employer fused large satoshi bundle carbon diagnose anatomy hamster leaves tracks paces beyond phantom capital marvel lips brave detect luck"
+                ],
+                "989baf9dcaad5b10ca33dfd8cc75e42477025dce88ae83e75a230086a0e00e92",
+            ],
+            [
+                "23. Basic sharing 2-of-3 (256 bits)",
+                [
+                    "humidity disease academic always aluminum jewelry energy woman receiver strategy amuse duckling lying evidence network walnut tactics forget hairy rebound impulse brother survive clothes stadium mailman rival ocean reward venture always armed unwrap",
+                    "humidity disease academic agency actress jacket gross physics cylinder solution fake mortgage benefit public busy prepare sharp friar change work slow purchase ruler again tricycle involve viral wireless mixture anatomy desert cargo upgrade",
+                ],
+                "c938b319067687e990e05e0da0ecce1278f75ff58d9853f19dcaeed5de104aae",
+            ],
+            [
+                "36. Threshold number of groups and members in each group (256 bits, case 1)",
+                [
+                    "wildlife deal ceramic round aluminum pitch goat racism employer miracle percent math decision episode dramatic editor lily prospect program scene rebuild display sympathy have single mustang junction relate often chemical society wits estate",
+                    "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+                    "wildlife deal ceramic scatter argue equip vampire together ruin reject literary rival distance aquatic agency teammate rebound false argue miracle stay again blessing peaceful unknown cover beard acid island language debris industry idle",
+                    "wildlife deal ceramic snake agree voter main lecture axis kitchen physics arcade velvet spine idea scroll promise platform firm sharp patrol divorce ancestor fantasy forbid goat ajar believe swimming cowboy symbolic plastic spelling",
+                    "wildlife deal decision shadow analysis adjust bulb skunk muscle mandate obesity total guitar coal gravity carve slim jacket ruin rebuild ancestor numerous hour mortgage require herd maiden public ceiling pecan pickup shadow club",
+                ],
+                "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+            ],
+            [
+                "37. Threshold number of groups and members in each group (256 bits, case 2)",
+                [
+                    "wildlife deal decision scared acne fatal snake paces obtain election dryer dominant romp tactics railroad marvel trust helpful flip peanut theory theater photo luck install entrance taxi step oven network dictate intimate listen",
+                    "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+                    "wildlife deal decision smug ancestor genuine move huge cubic strategy smell game costume extend swimming false desire fake traffic vegan senior twice timber submit leader payroll fraction apart exact forward pulse tidy install",
+                ],
+                "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+            ],
+            [
+                "38. Threshold number of groups and members in each group (256 bits, case 3)",
+                [
+                    "wildlife deal beard romp alcohol space mild usual clothes union nuclear testify course research heat listen task location thank hospital slice smell failure fawn helpful priest ambition average recover lecture process dough stadium",
+                    "wildlife deal acrobat romp anxiety axis starting require metric flexible geology game drove editor edge screw helpful have huge holy making pitch unknown carve holiday numb glasses survive already tenant adapt goat fangs",
+                ],
+                "5385577c8cfc6c1a8aa0f7f10ecde0a3318493262591e78b8c14c6686167123b",
+            ],
+        ]
+        for test_name, mnemonics, expected in test_cases:
+            share_set = ShareSet([Share.parse(m) for m in mnemonics])
+            self.assertEqual(share_set.recover(b"TREZOR").hex(), expected, test_name)
+
+    def test_split(self):
+        secret = bytes.fromhex("7c3397a292a5941682d7a4ae2d898d11")
+        for k, n in ((2, 3), (3, 5), (5, 5), (9, 9), (13, 15)):
+            share_data = ShareSet.split_secret(secret, k, n)
+            self.assertEqual(secret, ShareSet.interpolate(255, share_data[:k]))
+
+    def test_generate(self):
+        test_cases = ["zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo zoo wrong", "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold"]
+        for bip39_mnemonic in test_cases:
+            passphrase = b"embittest"
+            for k, n in ((2, 3), (3, 5), (5, 5), (9, 9), (13, 15), (2, 8)):
+                slip39_mnemonics = ShareSet.generate_shares(
+                    bip39_mnemonic, k, n, passphrase=passphrase, exponent=2
+                )
+                self.assertEqual(
+                    ShareSet.recover_mnemonic(slip39_mnemonics[:k], passphrase),
+                    bip39_mnemonic,
+                )


### PR DESCRIPTION
I'm not sure if I did the hashlib stuff correctly, but it passes all the test vectors except the very last one which is about error-correction.

I would love to see this eventually go downstream to Specter DIY