### PR TITLE
Basic taproot support

### DIFF
--- a/src/embit/base.py
+++ b/src/embit/base.py
@@ -9,6 +9,12 @@ class EmbitError(Exception):
     pass
 
 
+def copy(a:bytes) -> bytes:
+    """Ugly copy that works everywhere incl micropython"""
+    if len(a) == 0:
+        return b""
+    return a[:1] + a[1:]
+
 class EmbitBase:
     @classmethod
     def read_from(cls, stream, *args, **kwargs):

--- a/src/embit/descriptor/arguments.py
+++ b/src/embit/descriptor/arguments.py
@@ -357,22 +357,18 @@ class KeyHash(Key):
     @classmethod
     def parse_key(cls, k: bytes, *args, **kwargs):
         # convert to string
-        k = k.decode()
+        kd = k.decode()
         # raw 20-byte hash
-        if len(k) == 40:
-            return k
-        if len(k) in [66, 130] and k[:2] in ["02", "03", "04"]:
-            # bare public key
-            return ec.PublicKey.parse(unhexlify(k))
-        elif k[1:4] in ["pub", "prv"]:
-            # bip32 key
-            return bip32.HDKey.from_base58(k)
-        else:
-            return ec.PrivateKey.from_wif(k)
+        if len(kd) == 40:
+            return kd
+        return super().parse_key(k, *args, **kwargs)
 
     def serialize(self, *args, **kwargs):
         if isinstance(self.key, str):
             return unhexlify(self.key)
+        # TODO: should it be xonly?
+        if self.taproot:
+            return hashes.hash160(self.key.sec()[1:33])
         return hashes.hash160(self.key.sec())
 
     def __len__(self):

--- a/src/embit/descriptor/arguments.py
+++ b/src/embit/descriptor/arguments.py
@@ -269,6 +269,13 @@ class Key(DescriptorBase):
     def sec(self):
         return self.key.sec()
 
+    def xonly(self):
+        return self.key.xonly()
+
+    def taproot_tweak(self, h=b""):
+        assert self.taproot
+        return self.key.taproot_tweak(h)
+
     def serialize(self):
         if self.taproot:
             return self.sec()[1:33]

--- a/src/embit/ec.py
+++ b/src/embit/ec.py
@@ -176,7 +176,7 @@ class PrivateKey(EmbitKey):
             secret = secp256k1.ec_privkey_negate(self._secret)
         else:
             secret = self._secret
-        res = secp256k1.ec_privkey_tweak_add(secret, tweak)
+        res = secp256k1.ec_privkey_add(secret, tweak)
         pk = PrivateKey(res)
         if pk.sec()[0] == 0x03:
             pk = PrivateKey(secp256k1.ec_privkey_negate(res))

--- a/src/embit/hashes.py
+++ b/src/embit/hashes.py
@@ -26,3 +26,9 @@ def tagged_hash(tag: str, data: bytes) -> bytes:
     """BIP-Schnorr tag-specific key derivation"""
     hashtag = hashlib.sha256(tag.encode()).digest()
     return hashlib.sha256(hashtag + hashtag + data).digest()
+
+def tagged_hash_init(tag: str, data: bytes):
+    """Prepares a tagged hash function to digest extra data"""
+    hashtag = hashlib.sha256(tag.encode()).digest()
+    h = hashlib.sha256(hashtag + hashtag + data)
+    return h

--- a/src/embit/liquid/descriptor.py
+++ b/src/embit/liquid/descriptor.py
@@ -52,7 +52,7 @@ class LDescriptor(Descriptor):
         if not start.startswith(b"blinded("):
             s.seek(-8, 1)
             d = Descriptor.read_from(s)
-            return cls(d.miniscript, sh=d.sh, wsh=d.wsh, key=d.key, wpkh=d.wpkh, blinding_key=None)
+            return cls(d.miniscript, sh=d.sh, wsh=d.wsh, key=d.key, wpkh=d.wpkh, blinding_key=None, taproot=d.taproot)
 
         blinding_key = BlindingKey.read_from(s)
         if s.read(1) != b",":
@@ -65,7 +65,7 @@ class LDescriptor(Descriptor):
                 raise DescriptorError("Wildcards mismatch in blinded key and descriptor")
             if blinding_key.num_branches != d.num_branches:
                 raise DescriptorError("Branches mismatch in blinded key and descriptor")
-        return cls(d.miniscript, sh=d.sh, wsh=d.wsh, key=d.key, wpkh=d.wpkh, blinding_key=blinding_key)
+        return cls(d.miniscript, sh=d.sh, wsh=d.wsh, key=d.key, wpkh=d.wpkh, blinding_key=blinding_key, taproot=d.taproot)
 
     def to_string(self, blinded=True):
         res = super().to_string()

--- a/src/embit/transaction.py
+++ b/src/embit/transaction.py
@@ -28,6 +28,20 @@ class SIGHASH:
             raise TransactionError("Invalid SIGHASH type")
         return sighash, anyonecanpay
 
+# util functions
+
+def hash_amounts(amounts):
+    h = hashlib.sha256()
+    for a in amounts:
+        h.update(a.to_bytes(8, "little"))
+    return h.digest()
+
+def hash_script_pubkeys(script_pubkeys):
+    h = hashlib.sha256()
+    for sc in script_pubkeys:
+        h.update(sc.serialize())
+    return h.digest()
+
 # API similar to bitcoin-cli decoderawtransaction
 
 
@@ -172,18 +186,12 @@ class Transaction(EmbitBase):
 
     def hash_amounts(self, amounts):
         if self._hash_amounts is None:
-            h = hashlib.sha256()
-            for a in amounts:
-                h.update(a.to_bytes(8, "little"))
-            self._hash_amounts = h.digest()
+            self._hash_amounts = hash_amounts(amounts)
         return self._hash_amounts
 
     def hash_script_pubkeys(self, script_pubkeys):
         if self._hash_script_pubkeys is None:
-            h = hashlib.sha256()
-            for sc in script_pubkeys:
-                h.update(sc.serialize())
-            self._hash_script_pubkeys = h.digest()
+            self._hash_script_pubkeys = hash_script_pubkeys(script_pubkeys)
         return self._hash_script_pubkeys
 
     def sighash_taproot(self, input_index, script_pubkeys, values, sighash=SIGHASH.DEFAULT):

--- a/src/embit/util/ctypes_secp256k1.py
+++ b/src/embit/util/ctypes_secp256k1.py
@@ -528,22 +528,20 @@ def ec_pubkey_negate(pubkey, context=_secp.ctx):
 def ec_privkey_tweak_add(secret, tweak, context=_secp.ctx):
     if len(secret) != 32 or len(tweak) != 32:
         raise ValueError("Secret and tweak should both be 32 bytes long")
-    b = _copy(secret)
     t = _copy(tweak)
-    if _secp.secp256k1_ec_privkey_tweak_add(context, b, tweak) == 0:
+    if _secp.secp256k1_ec_privkey_tweak_add(context, secret, tweak) == 0:
         raise ValueError("Failed to tweak the secret")
-    return b
+    return None
 
 def ec_pubkey_tweak_add(pub, tweak, context=_secp.ctx):
     if len(pub) != 64:
         raise ValueError("Public key should be 64 bytes long")
     if len(tweak) != 32:
         raise ValueError("Tweak should be 32 bytes long")
-    b = _copy(pub)
     t = _copy(tweak)
     if _secp.secp256k1_ec_pubkey_tweak_add(context, pub, tweak) == 0:
         raise ValueError("Failed to tweak the public key")
-    return b
+    return None
 
 
 def ec_privkey_add(secret, tweak, context=_secp.ctx):

--- a/src/embit/util/ctypes_secp256k1.py
+++ b/src/embit/util/ctypes_secp256k1.py
@@ -27,6 +27,11 @@ CONTEXT_NONE = 0b0000000001
 EC_COMPRESSED = 0b0100000010
 EC_UNCOMPRESSED = 0b0000000010
 
+def _copy(a:bytes) -> bytes:
+    """Ugly copy that works everywhere incl micropython"""
+    if len(a) == 0:
+        return b""
+    return a[:1] + a[1:]
 
 def _find_library():
     library_path = None
@@ -162,6 +167,43 @@ def _init(flags=(CONTEXT_SIGN | CONTEXT_VERIFY)):
     ]
     secp256k1.secp256k1_ec_pubkey_combine.restype = c_int
 
+    # schnorr sig
+    try:
+        secp256k1.secp256k1_xonly_pubkey_from_pubkey.argtypes = [
+            c_void_p, # ctx
+            c_char_p, # xonly pubkey
+            POINTER(c_int), # parity
+            c_char_p, # pubkey
+        ]
+        secp256k1.secp256k1_xonly_pubkey_from_pubkey.restype = c_int
+
+        secp256k1.secp256k1_schnorrsig_verify.argtypes = [
+            c_void_p, # ctx
+            c_char_p, # sig
+            c_char_p, # msg
+            c_char_p, # pubkey
+        ]
+        secp256k1.secp256k1_schnorrsig_verify.restype = c_int
+
+        secp256k1.secp256k1_schnorrsig_sign.argtypes = [
+            c_void_p, # ctx
+            c_char_p, # sig
+            c_char_p, # msg
+            c_char_p, # keypair
+            c_void_p, # nonce_function
+            c_char_p, # extra data
+        ]
+        secp256k1.secp256k1_schnorrsig_sign.restype = c_int
+
+        secp256k1.secp256k1_keypair_create.argtypes = [
+            c_void_p, # ctx
+            c_char_p, # keypair
+            c_char_p, # secret
+        ]
+        secp256k1.secp256k1_keypair_create.restype = c_int
+    except:
+        pass
+
     # recoverable module
     try:
         secp256k1.secp256k1_ecdsa_sign_recoverable.argtypes = [
@@ -273,9 +315,6 @@ def _init(flags=(CONTEXT_SIGN | CONTEXT_VERIFY)):
         secp256k1.secp256k1_rangeproof_sign.restype = c_int
 
         # musig
-        secp256k1.secp256k1_xonly_pubkey_from_pubkey.argtypes = [c_void_p, c_char_p, POINTER(c_int), c_char_p]
-        secp256k1.secp256k1_xonly_pubkey_from_pubkey.restype = c_int
-
         secp256k1.secp256k1_musig_pubkey_combine.argtypes = [c_void_p, c_void_p, c_char_p, c_void_p, c_void_p, c_size_t]
         secp256k1.secp256k1_musig_pubkey_combine.restype = c_int
 
@@ -471,7 +510,7 @@ def ec_seckey_verify(secret, context=_secp.ctx):
 def ec_privkey_negate(secret, context=_secp.ctx):
     if len(secret) != 32:
         raise ValueError("Secret should be 32 bytes long")
-    b = secret[:1] + secret[1:]
+    b = _copy(secret)
     _secp.secp256k1_ec_privkey_negate(context, b)
     return b
 
@@ -479,7 +518,7 @@ def ec_privkey_negate(secret, context=_secp.ctx):
 def ec_pubkey_negate(pubkey, context=_secp.ctx):
     if len(pubkey) != 64:
         raise ValueError("Pubkey should be a 64-byte structure")
-    pub = pubkey[:1] + pubkey[1:]
+    pub = _copy(pubkey)
     r = _secp.secp256k1_ec_pubkey_negate(context, pub)
     if r == 0:
         raise ValueError("Failed to negate pubkey")
@@ -489,25 +528,31 @@ def ec_pubkey_negate(pubkey, context=_secp.ctx):
 def ec_privkey_tweak_add(secret, tweak, context=_secp.ctx):
     if len(secret) != 32 or len(tweak) != 32:
         raise ValueError("Secret and tweak should both be 32 bytes long")
-    if _secp.secp256k1_ec_privkey_tweak_add(context, secret, tweak) == 0:
+    b = _copy(secret)
+    t = _copy(tweak)
+    if _secp.secp256k1_ec_privkey_tweak_add(context, b, tweak) == 0:
         raise ValueError("Failed to tweak the secret")
-
+    return b
 
 def ec_pubkey_tweak_add(pub, tweak, context=_secp.ctx):
     if len(pub) != 64:
         raise ValueError("Public key should be 64 bytes long")
     if len(tweak) != 32:
         raise ValueError("Tweak should be 32 bytes long")
+    b = _copy(pub)
+    t = _copy(tweak)
     if _secp.secp256k1_ec_pubkey_tweak_add(context, pub, tweak) == 0:
         raise ValueError("Failed to tweak the public key")
+    return b
 
 
 def ec_privkey_add(secret, tweak, context=_secp.ctx):
     if len(secret) != 32 or len(tweak) != 32:
         raise ValueError("Secret and tweak should both be 32 bytes long")
     # ugly copy that works in mpy and py
-    s = secret[:1] + secret[1:]
-    if _secp.secp256k1_ec_privkey_tweak_add(context, s, tweak) == 0:
+    s = _copy(secret)
+    t = _copy(tweak)
+    if _secp.secp256k1_ec_privkey_tweak_add(context, s, t) == 0:
         raise ValueError("Failed to tweak the secret")
     return s
 
@@ -517,7 +562,7 @@ def ec_pubkey_add(pub, tweak, context=_secp.ctx):
         raise ValueError("Public key should be 64 bytes long")
     if len(tweak) != 32:
         raise ValueError("Tweak should be 32 bytes long")
-    p = pub[:1] + pub[1:]
+    p = _copy(pub)
     if _secp.secp256k1_ec_pubkey_tweak_add(context, p, tweak) == 0:
         raise ValueError("Failed to tweak the public key")
     return p
@@ -547,7 +592,45 @@ def ec_pubkey_combine(*args, context=_secp.ctx):
         raise ValueError("Failed to combine pubkeys")
     return pub
 
+# schnorrsig
+def xonly_pubkey_from_pubkey(pubkey, context=_secp.ctx):
+    if len(pubkey)!=64:
+        raise ValueError("Pubkey should be 64 bytes long")
+    pointer = POINTER(c_int)
+    parity = pointer(c_int(0))
+    xonly_pub = bytes(64)
+    res = _secp.secp256k1_xonly_pubkey_from_pubkey(context, xonly_pub, parity, pubkey)
+    if res != 1:
+        raise RuntimeError("Failed to convert the pubkey")
+    return xonly_pub, bool(parity.contents.value)
 
+def schnorrsig_verify(sig, msg, pubkey, context=_secp.ctx):
+    assert len(sig) == 64
+    assert len(msg) == 32
+    assert len(pubkey) == 64
+    res = _secp.secp256k1_schnorrsig_verify(context, sig, msg, pubkey)
+    return bool(res)
+
+def keypair_create(secret, context=_secp.ctx):
+    assert len(secret) == 32
+    keypair = bytes(96)
+    r = _secp.secp256k1_keypair_create(context, keypair, secret)
+    if r == 0:
+        raise ValueError("Failed to create keypair")
+    return keypair
+
+def schnorrsig_sign(msg, keypair, nonce_function=None, extra_data=None, context=_secp.ctx):
+    assert len(msg) == 32
+    if len(keypair) == 32:
+        keypair = keypair_create(keypair, context=context)
+    assert len(keypair) == 96
+    sig = bytes(64)
+    r = _secp.secp256k1_schnorrsig_sign(context, sig, msg, keypair, nonce_function, extra_data)
+    if r == 0:
+        raise ValueError("Failed to sign")
+    return sig
+
+# recoverable
 def ecdsa_sign_recoverable(msg, secret, context=_secp.ctx):
     if len(msg) != 32:
         raise ValueError("Message should be 32 bytes long")
@@ -741,17 +824,6 @@ def rangeproof_sign(nonce, value, value_commitment, vbf, message, extra, gen, mi
     if res != 1:
         raise RuntimeError("Failed to generate the proof")
     return bytes(proof[:prooflen.contents.value])
-
-def xonly_pubkey_from_pubkey(pubkey, context=_secp.ctx):
-    if len(pubkey)!=64:
-        raise ValueError("Pubkey should be 64 bytes long")
-    pointer = POINTER(c_int)
-    parity = pointer(c_int(0))
-    xonly_pub = bytes(64)
-    res = _secp.secp256k1_xonly_pubkey_from_pubkey(context, xonly_pub, parity, pubkey)
-    if res != 1:
-        raise RuntimeError("Failed to convert the pubkey")
-    return xonly_pub, bool(parity.contents.value)
 
 def musig_pubkey_combine(*args, context=_secp.ctx):
     pub = bytes(64)

--- a/src/embit/util/key.py
+++ b/src/embit/util/key.py
@@ -4,7 +4,13 @@ This is a fallback option if the library can't do ctypes bindings to secp256k1 l
 """
 import random
 import hmac
+import hashlib
 
+def TaggedHash(tag, data):
+    ss = hashlib.sha256(tag.encode('utf-8')).digest()
+    ss += ss
+    ss += data
+    return hashlib.sha256(ss).digest()
 
 def modinv(a, n):
     """Compute the modular inverse of a modulo n using the extended Euclidean
@@ -505,3 +511,57 @@ def tweak_add_pubkey(key, tweak):
     if Q is None:
         return None
     return (Q[0].to_bytes(32, "big"), not SECP256K1.has_even_y(Q))
+
+def verify_schnorr(key, sig, msg):
+    """Verify a Schnorr signature (see BIP 340).
+    - key is a 32-byte xonly pubkey (computed using compute_xonly_pubkey).
+    - sig is a 64-byte Schnorr signature
+    - msg is a 32-byte message
+    """
+    assert len(key) == 32
+    assert len(msg) == 32
+    assert len(sig) == 64
+
+    x_coord = int.from_bytes(key, 'big')
+    if x_coord == 0 or x_coord >= SECP256K1_FIELD_SIZE:
+        return False
+    P = SECP256K1.lift_x(x_coord)
+    if P is None:
+        return False
+    r = int.from_bytes(sig[0:32], 'big')
+    if r >= SECP256K1_FIELD_SIZE:
+        return False
+    s = int.from_bytes(sig[32:64], 'big')
+    if s >= SECP256K1_ORDER:
+        return False
+    e = int.from_bytes(TaggedHash("BIP0340/challenge", sig[0:32] + key + msg), 'big') % SECP256K1_ORDER
+    R = SECP256K1.mul([(SECP256K1_G, s), (P, SECP256K1_ORDER - e)])
+    if not SECP256K1.has_even_y(R):
+        return False
+    if ((r * R[2] * R[2]) % SECP256K1_FIELD_SIZE) != R[0]:
+        return False
+    return True
+
+def sign_schnorr(key, msg, aux=None, flip_p=False, flip_r=False):
+    """Create a Schnorr signature (see BIP 340)."""
+
+    if aux is None:
+        aux = bytes(32)
+
+    assert len(key) == 32
+    assert len(msg) == 32
+    assert len(aux) == 32
+
+    sec = int.from_bytes(key, 'big')
+    if sec == 0 or sec >= SECP256K1_ORDER:
+        return None
+    P = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, sec)]))
+    if SECP256K1.has_even_y(P) == flip_p:
+        sec = SECP256K1_ORDER - sec
+    t = (sec ^ int.from_bytes(TaggedHash("BIP0340/aux", aux), 'big')).to_bytes(32, 'big')
+    kp = int.from_bytes(TaggedHash("BIP0340/nonce", t + P[0].to_bytes(32, 'big') + msg), 'big') % SECP256K1_ORDER
+    assert kp != 0
+    R = SECP256K1.affine(SECP256K1.mul([(SECP256K1_G, kp)]))
+    k = kp if SECP256K1.has_even_y(R) != flip_r else SECP256K1_ORDER - kp
+    e = int.from_bytes(TaggedHash("BIP0340/challenge", R[0].to_bytes(32, 'big') + P[0].to_bytes(32, 'big') + msg), 'big') % SECP256K1_ORDER
+    return R[0].to_bytes(32, 'big') + ((k + e * sec) % SECP256K1_ORDER).to_bytes(32, 'big')

--- a/tests/integration/tests/test_psbt.py
+++ b/tests/integration/tests/test_psbt.py
@@ -1,7 +1,6 @@
 from unittest import TestCase, skip
 from util.bitcoin import daemon
 import random
-import time
 from embit.descriptor import Descriptor
 from embit.descriptor.checksum import add_checksum
 from embit.bip32 import HDKey

--- a/tests/tests/test_bindings.py
+++ b/tests/tests/test_bindings.py
@@ -87,11 +87,17 @@ class BindingsTest(TestCase):
             pub2, par = py_secp256k1.xonly_pubkey_from_pubkey(pub2)
             self.assertEqual(pub1, pub2)
             msg = b"q"*32
+
+            # without aux data
             sig1 = ctypes_secp256k1.schnorrsig_sign(msg, secret)
             sig2 = py_secp256k1.schnorrsig_sign(msg, secret)
-            # nonce generation seems to be diffrerent
-            # so we just check that signatures are valid
-            # in both implementations
+            self.assertEqual(sig1, sig2)
+
+            # with aux data
+            sig1 = ctypes_secp256k1.schnorrsig_sign(msg, secret, None, b"4"*32)
+            sig2 = py_secp256k1.schnorrsig_sign(msg, secret, None, b"4"*32)
+            self.assertEqual(sig1, sig2)
+
             self.assertTrue(ctypes_secp256k1.schnorrsig_verify(sig1, msg, pub1))
             self.assertTrue(py_secp256k1.schnorrsig_verify(sig2, msg, pub2))
             self.assertTrue(ctypes_secp256k1.schnorrsig_verify(sig2, msg, pub1))

--- a/tests/tests/test_taproot.py
+++ b/tests/tests/test_taproot.py
@@ -3,10 +3,15 @@ from embit.bip32 import HDKey
 from embit.networks import NETWORKS
 from embit.script import p2tr, address_to_scriptpubkey
 from embit.descriptor import Descriptor
+from embit.psbt import PSBT
 
 KEY = "tprv8ZgxMBicQKsPf27gmh4DbQqN2K6xnXA7m7AeceqQVGkRYny3X49sgcufzbJcq4k5eaGZDMijccdDzvQga2Saqd78dKqN52QwLyqgY8apX3j"
 ROOT = HDKey.from_string(KEY)
 NET = NETWORKS["regtest"]
+
+# tx without derivations. inp0 should be signed with addr0, inp1 with addr1
+B64PSBT = "cHNidP8BAKYCAAAAAsBlMEaxkJwNZ6V+BZ06bKIb5q2CpF9sHDDj0/eJfzA1AAAAAAD+////kqnvuD+I8rLf8eELSAqvqBiEy5+IpOKpn/acu+gs0E8BAAAAAP7///8CAA4nBwAAAAAWABStYQVCeoRPwINTcqOPmDkTReYZVbjCyQEAAAAAIlEgDTyyEUjN1Oyxc6Z5xifyM3Kamy+Hrt0UdV86CeDMvf8AAAAAAAEAfQIAAAABRL1RocN1LnP4aONGuWFAJm0+Hej0SWAqlSlJ9caTP/gBAAAAAP7///8CAOH1BQAAAAAiUSBCFZNDTJDvmyVvyzL/thnwUyHGSdn0HDwInUIk/SHzmc4uGh4BAAAAFgAU1ZjhFjq1hmtoVb2+6O7jHrtqYsDLAAAAAQErAOH1BQAAAAAiUSBCFZNDTJDvmyVvyzL/thnwUyHGSdn0HDwInUIk/SHzmQABAH0CAAAAAcBlMEaxkJwNZ6V+BZ06bKIb5q2CpF9sHDDj0/eJfzA1AQAAAAD+////ArU9HxsBAAAAFgAUOGUymdaBcR3nQVoZ804qGf9H9iKA8PoCAAAAACJRIDrGIL80dDh9Y5xIBek776O9xpVrAtiuyiy8HXZSuTUZzAAAAAEBK4Dw+gIAAAAAIlEgOsYgvzR0OH1jnEgF6Tvvo73GlWsC2K7KLLwddlK5NRkAAAA="
+B64SIGNED = "cHNidP8BAKYCAAAAAsBlMEaxkJwNZ6V+BZ06bKIb5q2CpF9sHDDj0/eJfzA1AAAAAAD+////kqnvuD+I8rLf8eELSAqvqBiEy5+IpOKpn/acu+gs0E8BAAAAAP7///8CAA4nBwAAAAAWABStYQVCeoRPwINTcqOPmDkTReYZVbjCyQEAAAAAIlEgDTyyEUjN1Oyxc6Z5xifyM3Kamy+Hrt0UdV86CeDMvf8AAAAAAAEAfQIAAAABRL1RocN1LnP4aONGuWFAJm0+Hej0SWAqlSlJ9caTP/gBAAAAAP7///8CAOH1BQAAAAAiUSBCFZNDTJDvmyVvyzL/thnwUyHGSdn0HDwInUIk/SHzmc4uGh4BAAAAFgAU1ZjhFjq1hmtoVb2+6O7jHrtqYsDLAAAAAQErAOH1BQAAAAAiUSBCFZNDTJDvmyVvyzL/thnwUyHGSdn0HDwInUIk/SHzmQEIQwFBApOkiV6PkijNENaddILURidJhTlnK3EnYT1zPnksBel0HHz4TyPDhF3VJA0RG480dr0yAy1l1agcbyZFKduv9QEAAQB9AgAAAAHAZTBGsZCcDWelfgWdOmyiG+atgqRfbBww49P3iX8wNQEAAAAA/v///wK1PR8bAQAAABYAFDhlMpnWgXEd50FaGfNOKhn/R/YigPD6AgAAAAAiUSA6xiC/NHQ4fWOcSAXpO++jvcaVawLYrsosvB12Urk1GcwAAAABASuA8PoCAAAAACJRIDrGIL80dDh9Y5xIBek776O9xpVrAtiuyiy8HXZSuTUZAQhDAUGRfNtYnHLUoAOM57UwVvcuqe0bUAiaO5PAnxp0AcyqdrV3d4Q8303FOCNp8SUDlbTs2idGiNqa+TCaUVQC6AmdAQAAAA=="
 
 DERIVED_ADDRESSES = [
   "bcrt1pgg2exs6vjrhekft0eve0ldse7pfjr3jfm86pc0qgn4pzflfp7wvsc0kwqa",
@@ -50,3 +55,10 @@ class TaprootTest(TestCase):
         Descriptor.from_string("tr(b4ca2da5380d9aeb5ca67e4f18c487ae9b668748517e12b788496f63765e2efa)")
         with self.assertRaises(Exception):
             Descriptor.from_string("wpkh(b4ca2da5380d9aeb5ca67e4f18c487ae9b668748517e12b788496f63765e2efa)")
+
+    def test_sign_verify(self):
+        unsigned = PSBT.from_string(B64PSBT)
+        signed = PSBT.from_string(B64SIGNED)
+        tx = unsigned.tx
+        hsh = tx.sighash_taproot()
+        # sig = SchnorrSig

--- a/tests/tests/test_taproot.py
+++ b/tests/tests/test_taproot.py
@@ -40,3 +40,13 @@ class TaprootTest(TestCase):
             addr = d.address(NET)
             self.assertEqual(addr, expected)
             self.assertEqual(d.script_pubkey(), address_to_scriptpubkey(expected))
+
+    def test_invalid(self):
+        with self.assertRaises(Exception):
+            Descriptor.from_string("wsh(tr(%s/0/*))" % ROOT)
+        with self.assertRaises(Exception):
+            Descriptor.from_string("sh(tr(%s/0/*))" % ROOT)
+        # x-only is only allowed in tr
+        Descriptor.from_string("tr(b4ca2da5380d9aeb5ca67e4f18c487ae9b668748517e12b788496f63765e2efa)")
+        with self.assertRaises(Exception):
+            Descriptor.from_string("wpkh(b4ca2da5380d9aeb5ca67e4f18c487ae9b668748517e12b788496f63765e2efa)")

--- a/tests/tests/test_taproot.py
+++ b/tests/tests/test_taproot.py
@@ -5,6 +5,7 @@ from embit.script import p2tr, address_to_scriptpubkey
 from embit.descriptor import Descriptor
 from embit.psbt import PSBT
 from embit.ec import SchnorrSig, PublicKey
+from embit.transaction import SIGHASH
 
 KEY = "tprv8ZgxMBicQKsPf27gmh4DbQqN2K6xnXA7m7AeceqQVGkRYny3X49sgcufzbJcq4k5eaGZDMijccdDzvQga2Saqd78dKqN52QwLyqgY8apX3j"
 ROOT = HDKey.from_string(KEY)


### PR DESCRIPTION
Adds support for taproot single-key scripts (without embedded scripts)

Tasks:
- [x] ctypes binding to schnorr sign & verify
- [x] pure python implementation of schnorr
- [x] micropython bindings (https://github.com/diybitcoinhardware/secp256k1-embedded/)
- [x] key tweaks for empty taproots
- [x] transaction sighash for taproot
- [x] psbt.sign_with() support
- [x] psbtview.sign_with() support