### PR TITLE
Try uio if io import fails

### DIFF
--- a/examples/change.py
+++ b/examples/change.py
@@ -7,8 +7,10 @@ Multisig transaction verification example:
 """
 from embit import bip39, bip32, psbt, script, ec
 from binascii import a2b_base64, b2a_base64
-from io import BytesIO
-
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 
 def parse_multisig(sc):
     """Takes a script and extracts m,n and pubkeys from it"""

--- a/src/embit/base.py
+++ b/src/embit/base.py
@@ -1,5 +1,8 @@
 """Base classes"""
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 from binascii import hexlify, unhexlify
 
 

--- a/src/embit/bcur.py
+++ b/src/embit/bcur.py
@@ -1,4 +1,7 @@
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 import hashlib
 
 CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"

--- a/src/embit/bip32.py
+++ b/src/embit/bip32.py
@@ -12,7 +12,6 @@ from . import base58
 from . import hashes
 import hmac
 from binascii import hexlify
-import io
 
 class HDError(EmbitError):
     pass

--- a/src/embit/compact.py
+++ b/src/embit/compact.py
@@ -1,6 +1,8 @@
 """ Compact Int parsing / serialization """
-import io
-
+try:
+	import io
+except ImportError:
+	import uio as io
 
 def to_bytes(i: int):
     """encodes an integer as a compact int"""

--- a/src/embit/descriptor/base.py
+++ b/src/embit/descriptor/base.py
@@ -1,5 +1,7 @@
-from io import BytesIO
-
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 
 def read_until(s, chars=b",)(#"):
     res = b""

--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -1,5 +1,8 @@
 from binascii import hexlify, unhexlify
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 from .. import hashes, compact, ec, bip32, script
 from ..networks import NETWORKS
 from .errors import DescriptorError

--- a/src/embit/descriptor/miniscript.py
+++ b/src/embit/descriptor/miniscript.py
@@ -1,5 +1,4 @@
 from binascii import hexlify, unhexlify
-from io import BytesIO
 from .. import hashes, compact, ec, bip32, script
 from ..networks import NETWORKS
 from .errors import MiniscriptError

--- a/src/embit/liquid/pset.py
+++ b/src/embit/liquid/pset.py
@@ -8,7 +8,6 @@ else:
 from .. import compact, hashes
 from ..psbt import *
 from collections import OrderedDict
-from io import BytesIO
 from .transaction import LTransaction, LTransactionOutput, LTransactionInput, TxOutWitness, Proof, LSIGHASH, unblind
 from . import slip77
 import hashlib

--- a/src/embit/liquid/transaction.py
+++ b/src/embit/liquid/transaction.py
@@ -1,4 +1,3 @@
-import io
 from .. import compact
 from ..script import Script, Witness
 from .. import hashes

--- a/src/embit/psbt.py
+++ b/src/embit/psbt.py
@@ -8,7 +8,10 @@ from .script import Script, Witness
 from . import script
 from .base import EmbitBase, EmbitError
 from binascii import b2a_base64, a2b_base64, hexlify, unhexlify
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 
 class PSBTError(EmbitError):
     pass

--- a/src/embit/transaction.py
+++ b/src/embit/transaction.py
@@ -1,5 +1,4 @@
 import sys
-import io
 import hashlib
 from . import compact
 from .script import Script, Witness

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 from binascii import hexlify
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 from embit.descriptor import Descriptor, Key
 from embit.descriptor.arguments import KeyHash, Number
 from embit.descriptor.miniscript import OPERATORS, WRAPPERS

--- a/tests/tests/test_ecc.py
+++ b/tests/tests/test_ecc.py
@@ -1,8 +1,10 @@
 from binascii import unhexlify, hexlify
 from unittest import TestCase
 from embit.ec import PublicKey, PrivateKey, Signature, secp256k1
-from io import BytesIO
-
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 
 class SECPTest(TestCase):
     def test_identity(self):

--- a/tests/tests/test_psbtview.py
+++ b/tests/tests/test_psbtview.py
@@ -3,7 +3,10 @@ from embit.psbtview import PSBTView
 from embit.psbt import PSBT, InputScope
 from embit import bip32, bip39
 from binascii import a2b_base64, b2a_base64
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 
 ROOT = bip32.HDKey.from_seed(bip39.mnemonic_to_seed("toy fault beef holiday later unit boring merge shield detail scrap negative"))
 # tprv8ZgxMBicQKsPeDhmZay7WoN2W9gkmZNv4bkPRgCsaqKAnafo2YkpmJFQUAv34PTdYciNteTu8A1tvDUBsusThseGfiPkdFAniazFzxRd8xv

--- a/tests/tests/test_taproot.py
+++ b/tests/tests/test_taproot.py
@@ -7,7 +7,10 @@ from embit.psbt import DerivationPath, PSBT
 from embit.ec import SchnorrSig, PublicKey
 from embit.transaction import SIGHASH
 from embit.psbtview import PSBTView
-from io import BytesIO
+try:
+	from io import BytesIO
+except ImportError:
+	from uio import BytesIO
 from binascii import a2b_base64
 
 KEY = "tprv8ZgxMBicQKsPf27gmh4DbQqN2K6xnXA7m7AeceqQVGkRYny3X49sgcufzbJcq4k5eaGZDMijccdDzvQga2Saqd78dKqN52QwLyqgY8apX3j"


### PR DESCRIPTION
This PR updates imports involving the `io` module so that they fall back to `uio` on failure to import. This was necessary to support the M5Stack family of devices which only includes the [MicroPython version of io](https://docs.micropython.org/en/latest/library/uio.html).

The files where I removed the imports entirely were ones in which the import was no longer being used/referenced.

Currently, my hardware wallet [Krux](https://github.com/jreesun/krux) is using a custom version of embit with these changes, but ideally I'd like to be able to reference this repo directly as a submodule instead.

Thanks for the great library!