### PR TITLE
switch to <m;n> multipart descriptors by default (bip-389)

### DIFF
--- a/examples/descriptor.py
+++ b/examples/descriptor.py
@@ -12,24 +12,25 @@ classic_descriptors = [
     """,
     "sh(wpkh([775658e7/49h/1h/0h]upub5Dhav3NrgESngrnJXvraLCn3TNTW4NYUk8sszdcxfyYfsMr9Uug1eLGW56369ofcGKCftCLGKnXGaPZRVvHiZnNAjECbWPuhP7N8Dba72z3/0/*))",
 ]
-# paired descriptors with a set of allowed branches defined in a set: {a,b,c}. Usually {0,1} is used for receive & change descriptor pairs.
+# paired descriptors with a set of allowed branches defined in a set: <a;b;c>.
+# Usually <0;1> is used for receive & change descriptor pairs.
 paired_descriptors = [
     """
     wsh(sortedmulti(2,
-        [775658e7/48h/1h/0h/1h]Upub5S3YzYL9wUjT9EVUpabdveZFQk9moQUuvXSb35vxbmFYAdEXd979eK27taPWaSmR9BH3nAkMbFWLFf4q3H59FA9zH8P6GQk7xSQuYVKSChj/{0,1}/*,
-        [3193f8d3/48h/1h/0h/2h]tpubDEKfK8pLLATjieRRMSLPq34RdmRuNpXrBWCeiG7K1qgHrM6x1e821VdmxAXBheTYmVpoyNPni2bhzZ4qfFjcHpmGmyrkzbxWy2gZ6LcecDq/{0,1}/*,
-        [9537bf0b/48h/1h/0h/2h]Vpub5m95PwsYnQp8krS98ygrRzxfacqdR3mCiFLnJbhtSTngm45EJg8UNSz9GGnoBc6dXMvievF3LSc2SakRn691Q9EwuDsVSafJNgf2CdzanzY/{0,1}/*
+        [775658e7/48h/1h/0h/1h]Upub5S3YzYL9wUjT9EVUpabdveZFQk9moQUuvXSb35vxbmFYAdEXd979eK27taPWaSmR9BH3nAkMbFWLFf4q3H59FA9zH8P6GQk7xSQuYVKSChj/<0;1>/*,
+        [3193f8d3/48h/1h/0h/2h]tpubDEKfK8pLLATjieRRMSLPq34RdmRuNpXrBWCeiG7K1qgHrM6x1e821VdmxAXBheTYmVpoyNPni2bhzZ4qfFjcHpmGmyrkzbxWy2gZ6LcecDq/<0;1>/*,
+        [9537bf0b/48h/1h/0h/2h]Vpub5m95PwsYnQp8krS98ygrRzxfacqdR3mCiFLnJbhtSTngm45EJg8UNSz9GGnoBc6dXMvievF3LSc2SakRn691Q9EwuDsVSafJNgf2CdzanzY/<0;1>/*
     ))
     """,
-    "wpkh([775658e7/84h/1h/0h]vpub5YomFkdenHbE1AbDaJV4kMfUh5UX4tt1Ed7B8mhSwyPxDw4wjim2qg4vd2vuYtYdsUUm9kmoCWLAbeABEY5HsMfeeN4okERNRUcmNXXgEBq/{33,45}/*)",
+    "wpkh([775658e7/84h/1h/0h]vpub5YomFkdenHbE1AbDaJV4kMfUh5UX4tt1Ed7B8mhSwyPxDw4wjim2qg4vd2vuYtYdsUUm9kmoCWLAbeABEY5HsMfeeN4okERNRUcmNXXgEBq/<33;45>/*)",
 ]
 # miniscript descriptors
 # Use http://bitcoin.sipa.be/miniscript/ to compile policy to miniscript
 miniscript_descriptors = [
     """wsh(or_d(
-        pk([775658e7/48h/1h/0h/1h]Upub5S3YzYL9wUjT9EVUpabdveZFQk9moQUuvXSb35vxbmFYAdEXd979eK27taPWaSmR9BH3nAkMbFWLFf4q3H59FA9zH8P6GQk7xSQuYVKSChj/{0,1}/*),
+        pk([775658e7/48h/1h/0h/1h]Upub5S3YzYL9wUjT9EVUpabdveZFQk9moQUuvXSb35vxbmFYAdEXd979eK27taPWaSmR9BH3nAkMbFWLFf4q3H59FA9zH8P6GQk7xSQuYVKSChj/<0;1>/*),
         and_v(
-            v:pkh([9537bf0b/48h/1h/0h/2h]Vpub5m95PwsYnQp8krS98ygrRzxfacqdR3mCiFLnJbhtSTngm45EJg8UNSz9GGnoBc6dXMvievF3LSc2SakRn691Q9EwuDsVSafJNgf2CdzanzY/{0,1}/*),
+            v:pkh([9537bf0b/48h/1h/0h/2h]Vpub5m95PwsYnQp8krS98ygrRzxfacqdR3mCiFLnJbhtSTngm45EJg8UNSz9GGnoBc6dXMvievF3LSc2SakRn691Q9EwuDsVSafJNgf2CdzanzY/<0;1>/*),
             older(14400)))
         )
     """
@@ -54,7 +55,8 @@ def main():
         desc = Descriptor.from_string(dstr)
         # print(desc.policy)
         # 12-th address, testnet, 1st branch (change)
-        # branch_index is the index of the allowed set, so if the set is {33,45} then branch_index=1 will derive using 45 index
+        # branch_index is the index of the allowed set, so if the set is <33;45>
+        # then branch_index=1 will derive using 45 index
         derived = desc.derive(12, branch_index=1)
         print("Derived descriptor:\n%s" % derived)
         addr = derived.address(NETWORKS['test'])

--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -27,9 +27,9 @@ GAP_LIMIT = 20
 # Here we use combined descriptor (Bitcoin Core doesn't support that though)
 # Here we use vpub, but it's the same as this tpub: tpubDC93uE1NfJMF37r4EL87CHBUEtScESkBNo6Ym3DYCqKdmdtsL8ZqK39aHfaESmSn9ZohH1vzQjDchsuAXRDGXuowXZSXj3fY7PJ9yBAhWst
 # native segwit
-desc = Descriptor.from_string("wpkh([911cf0a8/84h/1h/0h]vpub5Y6tmeqrefJq4jGy7RZmaBf6Zq44MpG7zwToqhNd6uoyv9bhkbPcvUAU1DaGvTBhYP3BAVDzxJgUF8BRhAY13zzSjHJNshNKyyaTS4F5hnr/{0,1}/*)")
-# desc = Descriptor.from_string("sh(wpkh([911cf0a8/49h/1h/0h]upub5EQTr2VnHFmuJc3btwZcETwhDCzvXF8hqK2AS57ZN5fzxa6LGMtoAKuyc12F7rBpKUyocqfc8kCTzHdTmJh1i6672pu3JzobNHu39oW9Btd/{0,1}/*))")
-# desc = Descriptor.from_string("pkh([911cf0a8/44h/1h/0h]tpubDD958ijpckkrCrWzY4jTwuCafkK1gijyJVbc96EViYN29Ac7K9eUyzSTrwQuoGUvwpzQMHh2fT8JGtnYHjTFWRXJAEs48s1nZSpG92hC1yb/{0,1}/*)")
+desc = Descriptor.from_string("wpkh([911cf0a8/84h/1h/0h]vpub5Y6tmeqrefJq4jGy7RZmaBf6Zq44MpG7zwToqhNd6uoyv9bhkbPcvUAU1DaGvTBhYP3BAVDzxJgUF8BRhAY13zzSjHJNshNKyyaTS4F5hnr/<0;1>/*)")
+# desc = Descriptor.from_string("sh(wpkh([911cf0a8/49h/1h/0h]upub5EQTr2VnHFmuJc3btwZcETwhDCzvXF8hqK2AS57ZN5fzxa6LGMtoAKuyc12F7rBpKUyocqfc8kCTzHdTmJh1i6672pu3JzobNHu39oW9Btd/<0;1>/*))")
+# desc = Descriptor.from_string("pkh([911cf0a8/44h/1h/0h]tpubDD958ijpckkrCrWzY4jTwuCafkK1gijyJVbc96EViYN29Ac7K9eUyzSTrwQuoGUvwpzQMHh2fT8JGtnYHjTFWRXJAEs48s1nZSpG92hC1yb/<0;1>/*)")
 
 # where to send
 DESTINATION = "2N6AUY73q79SPzGvgPhR9biETV7DZffTQz9"

--- a/examples/hdkey.py
+++ b/examples/hdkey.py
@@ -2,7 +2,6 @@ from embit import script
 from embit import bip32
 from embit import bip39
 from embit.networks import NETWORKS
-from binascii import unhexlify, hexlify
 import random
 
 # example of key and address derivations from mnemonic

--- a/src/embit/bip85.py
+++ b/src/embit/bip85.py
@@ -1,8 +1,8 @@
 from . import bip32, bip39, ec
+from .bip32 import HARDENED_INDEX
 import hmac
 
 BIP85_MAGIC = b"bip-entropy-from-k"
-H = 0x80000000
 
 class LANGUAGES:
     """
@@ -14,8 +14,11 @@ def derive_entropy(root, app_index, path):
     """
     Derive app-specific bip85 entropy using path m/83696968'/app_index'/...path'
     """
-    assert max(path) < H
-    derivation = [ H+83696968 ,H+app_index ] + [ p+H for p in path ]
+    assert max(path) < HARDENED_INDEX
+    derivation = [
+        HARDENED_INDEX + 83696968, 
+        HARDENED_INDEX + app_index
+    ] + [ p + HARDENED_INDEX for p in path ]
     derived = root.derive(derivation)
     return hmac.new(BIP85_MAGIC, derived.secret, digestmod='sha512').digest()
 

--- a/src/embit/descriptor/arguments.py
+++ b/src/embit/descriptor/arguments.py
@@ -328,6 +328,8 @@ class Key(DescriptorBase):
         return 1 if self.branches is None else len(self.branches)
 
     def branch(self, branch_index=None):
+        if self.allowed_derivation is None:
+            return self
         der = self.allowed_derivation.branch(branch_index)
         return type(self)(self.key, self.origin, der, self.taproot)
 

--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -1,6 +1,5 @@
-from binascii import hexlify, unhexlify
 from io import BytesIO
-from .. import hashes, compact, ec, bip32, script
+from .. import script
 from ..networks import NETWORKS
 from .errors import DescriptorError
 from .base import DescriptorBase

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 from binascii import hexlify
-from io import BytesIO
 from embit.descriptor import Descriptor, Key
 from embit.descriptor.arguments import KeyHash, Number
 from embit.descriptor.miniscript import OPERATORS, WRAPPERS
@@ -8,9 +7,9 @@ from embit.descriptor.miniscript import OPERATORS, WRAPPERS
 class DescriptorTest(TestCase):
     def test_descriptors(self):
         keys = [
-            "[abcdef12/84h/22h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/{0,1}/*",
+            "[abcdef12/84h/22h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/<0;1>/*",
             "03e7d285b4817f83f724cd29394da75dfc84fe639ed147a944e7e6064703b14130",
-            "[12345678/44h/12]xpub6BwcvdstHTJtLpp1WxUiQCYERWSB66XY5JrCpw71GAJxcJ6s2AiUoEK4Nzt6UDaTmanUiSe6TY2RoFturKNLXeWBhwBF6WBNghr8cr7qnjk/{0,1}/*",
+            "[12345678/44h/12]xpub6BwcvdstHTJtLpp1WxUiQCYERWSB66XY5JrCpw71GAJxcJ6s2AiUoEK4Nzt6UDaTmanUiSe6TY2RoFturKNLXeWBhwBF6WBNghr8cr7qnjk/<0;1>/*",
             "[12345a78/42h/15]03e7d285b4817f83f724cd29394da75dfc84fe639ed147a944e7e6064703b14130",    
         ]
 
@@ -98,7 +97,6 @@ class DescriptorTest(TestCase):
         ]
 
         for i,(d, a) in enumerate(dd):
-            s = BytesIO(d.encode())
             sc = Descriptor.from_string(d)
             self.assertEqual(str(sc), d)
             # get top level script
@@ -114,11 +112,11 @@ class DescriptorTest(TestCase):
             "[f45912ab/44h/12/32h]02edfc1d6088f9b6470ed4550d8bf2326ebebc0464a7f78581fa7283fc54edecf0",
             "02edfc1d6088f9b6470ed4550d8bf2326ebebc0464a7f78581fa7283fc54edecf0",
             "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/0/*",
-            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/{0,1}/*",
-            "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/0/56/*/{1,5}/54",
+            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/<0;1>/*",
+            "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/0/56/*/<1;5>/54",
             "KwF4aJaqLFBUyGpJqWWGBPJkDSXnEVwheaFNz5UEWqFPd43exAMB",
             "[f45912ab/44h/12/32h]KwF4aJaqLFBUyGpJqWWGBPJkDSXnEVwheaFNz5UEWqFPd43exAMB",
-            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/{0h,1}/34h/*",
+            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/<0h;1>/34h/*",
             # keyhash
             "a2edfc1d6088f9b6470ed4550d8bf2326ebebc04",
             "[f45912ab/44h/12/32h]a2edfc1d6088f9b6470ed4550d8bf2326ebebc04",
@@ -129,6 +127,33 @@ class DescriptorTest(TestCase):
             if kk.can_derive:
                 kkk = kk.derive(88)
                 self.assertFalse(kkk.can_derive)
+
+    def test_branch_compatibility(self):
+        keys = [
+            "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/<0>/*",
+            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/<0;1>/*",
+            "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/0/56/*/<1;5>/54",
+            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/<0h;1>/34h/*",
+        ]
+        for k in keys:
+            kk = Key.from_string(k.replace("<","{").replace(">","}").replace(";",","))
+            self.assertEqual(str(kk), k)
+            if kk.can_derive:
+                kkk = kk.derive(88)
+                self.assertFalse(kkk.can_derive)
+
+    def test_branch_mixing(self):
+        keys = [
+            "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/<0}/*",
+            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/{0;1}/*",
+            "[f45912ab/44h/12/32h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/0/56/*/<1,5>/54",
+            "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/<*;1>/34h/*",
+        ]
+        for k in keys:
+            self.assertRaises(
+                Exception,
+                Key.from_string, k
+            )
 
     def test_miniscript_compat(self):
         """Test we can parse Miniscript Descriptors created by other implementations"""
@@ -161,7 +186,7 @@ class DescriptorTest(TestCase):
 #   - wif
 #   - xprv
 #   - xpub/fixed
-#   - xpub/{allowed_set}/*
+#   - xpub/<allowed_set>/*
 #   - xpub/123/0/*/4
 #   - xpub/{receive:0,change:1,revault:2,whatever:4}/*
 #   - xpub/0/* should make it recv-only


### PR DESCRIPTION
Previously we used `{m,n}` to specify branches of descriptors, but looks like everyone is using `<m;n>` instead and there is an upcoming [bip](https://github.com/bitcoin/bips/pull/1354) specifying it.

Old way `{m,n}` is still supported, but by deafult string representation of `Key` arguments use `<m;n>`.