### PR TITLE
Taproot miniscript support

### DIFF
--- a/src/embit/descriptor/arguments.py
+++ b/src/embit/descriptor/arguments.py
@@ -336,9 +336,11 @@ class Key(DescriptorBase):
         return 1 if self.branches is None else len(self.branches)
 
     def branch(self, branch_index=None):
-        if self.allowed_derivation is None:
-            return self
-        der = self.allowed_derivation.branch(branch_index)
+        der = (
+            self.allowed_derivation.branch(branch_index) 
+            if self.allowed_derivation is not None
+            else None
+        )
         return type(self)(self.key, self.origin, der, self.taproot)
 
     @property

--- a/src/embit/descriptor/arguments.py
+++ b/src/embit/descriptor/arguments.py
@@ -27,9 +27,13 @@ class KeyOrigin:
 class AllowedDerivation(DescriptorBase):
     # xpub/<0;1>/* - <0;1> is a set of allowed branches, wildcard * is stored as None
     def __init__(self, indexes=[[0, 1], None]):
-        # check only one wildcard and only one set is in the derivation
-        if len([i for i in indexes if i is None]) > 1:
+        # check only one wildcard 
+        if len([i
+                for i in indexes
+                if i is None or (isinstance(i, list) and None in i)
+                ]) > 1:
             raise ArgumentError("Only one wildcard is allowed")
+        # check only one set is in the derivation
         if len([i for i in indexes if isinstance(i, list)]) > 1:
             raise ArgumentError("Only one set of branches is allowed")
         self.indexes = indexes

--- a/src/embit/descriptor/base.py
+++ b/src/embit/descriptor/base.py
@@ -4,7 +4,6 @@ from io import BytesIO
 def read_until(s, chars=b",)(#"):
     res = b""
     chunk = b""
-    char = None
     while True:
         chunk = s.read(1)
         if len(chunk) == 0:

--- a/src/embit/descriptor/taptree.py
+++ b/src/embit/descriptor/taptree.py
@@ -1,0 +1,41 @@
+from .errors import MiniscriptError
+from .base import DescriptorBase
+from .miniscript import Miniscript
+
+class TapTree(DescriptorBase):
+    def __init__(self, tree=None):
+        """tree can be None, Miniscript or a tuple (taptree, taptree)"""
+        self.tree = tree
+
+    @property
+    def keys(self):
+        # TODO: implement
+        return [] 
+
+    @classmethod
+    def read_from(cls, s):
+        c = s.read(1)
+        if len(c) == 0:
+            return cls()
+        if c == b"{": # more than one miniscript
+            left = cls.read_from(s)
+            c = s.read(1)
+            if c == b"}":
+                return left
+            if c != b",":
+                raise MiniscriptError("Invalid taptree syntax: expected ','")
+            right = cls.read_from(s)
+            if s.read(1) != b"}":
+                raise MiniscriptError("Invalid taptree syntax: expected '}'")
+            return cls((left, right))
+        s.seek(-1, 1)
+        ms = Miniscript.read_from(s)
+        return cls(ms)
+
+    def __str__(self):
+        if self.tree is None:
+            return ""
+        if isinstance(self.tree, Miniscript):
+            return str(self.tree)
+        (left, right) = self.tree
+        return "{%s,%s}" % (left, right)

--- a/src/embit/descriptor/taptree.py
+++ b/src/embit/descriptor/taptree.py
@@ -1,16 +1,100 @@
 from .errors import MiniscriptError
 from .base import DescriptorBase
 from .miniscript import Miniscript
+from ..hashes import tagged_hash
+from ..script import Script
 
-class TapTree(DescriptorBase):
-    def __init__(self, tree=None):
-        """tree can be None, Miniscript or a tuple (taptree, taptree)"""
-        self.tree = tree
+
+class TapLeaf(DescriptorBase):
+
+    def __init__(self, miniscript=None, version = 0xc0):
+        self.miniscript = miniscript
+        self.version = version
+
+    def __str__(self):
+        return str(self.miniscript)
+
+    @classmethod
+    def read_from(cls, s):
+        ms = Miniscript.read_from(s)
+        return cls(ms)
+
+    def serialize(self):
+        if self.miniscript is None:
+            return b""
+        return bytes([self.version])+Script(self.miniscript.compile()).serialize()
 
     @property
     def keys(self):
-        # TODO: implement
-        return [] 
+        return self.miniscript.keys
+
+    def derive(self, *args, **kwargs):
+        if self.miniscript is None:
+            return type(self)(None, version=self.version)
+        return type(self)(
+            self.miniscript.derive(*args, **kwargs),
+            self.version,
+        )
+
+    def branch(self, *args, **kwargs):
+        if self.miniscript is None:
+            return type(self)(None, version=self.version)
+        return type(self)(
+            self.miniscript.branch(*args, **kwargs),
+            self.version,
+        )
+
+    def to_public(self, *args, **kwargs):
+        if self.miniscript is None:
+            return type(self)(None, version=self.version)
+        return type(self)(
+            self.miniscript.to_public(*args, **kwargs),
+            self.version,
+        )
+
+def _tweak_helper(tree):
+    # https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#constructing-and-spending-taproot-outputs
+    if isinstance(tree, TapTree):
+        tree = tree.tree
+    if isinstance(tree, TapLeaf):
+        # one leaf on this branch
+        h = tagged_hash("TapLeaf", tree.serialize())
+        return ([(tree, b"")], h)
+    left, left_h = _tweak_helper(tree[0])
+    right, right_h = _tweak_helper(tree[1])
+    ret = (
+        [(leaf, c + right_h) for leaf, c in left] +
+        [(leaf, c + left_h) for leaf, c in right]
+    )
+    if right_h < left_h:
+        left_h, right_h = right_h, left_h
+    return (ret, tagged_hash("TapBranch", left_h + right_h))
+
+class TapTree(DescriptorBase):
+    def __init__(self, tree=None):
+        """tree can be None, TapLeaf or a tuple (taptree, taptree)"""
+        self.tree = tree
+        # make sure all keys are taproot
+        for k in self.keys:
+            k.taproot = True
+
+    def __bool__(self):
+        return bool(self.tree)
+
+    def tweak(self):
+        if self.tree is None:
+            return b""
+        _, h = _tweak_helper(self.tree)
+        return h
+
+    @property
+    def keys(self):
+        if self.tree is None:
+            return []
+        if isinstance(self.tree, TapLeaf):
+            return self.tree.keys
+        left, right = self.tree
+        return left.keys + right.keys
 
     @classmethod
     def read_from(cls, s):
@@ -29,13 +113,38 @@ class TapTree(DescriptorBase):
                 raise MiniscriptError("Invalid taptree syntax: expected '}'")
             return cls((left, right))
         s.seek(-1, 1)
-        ms = Miniscript.read_from(s)
+        ms = TapLeaf.read_from(s)
         return cls(ms)
+
+    def derive(self, *args, **kwargs):
+        if self.tree is None:
+            return type(self)(None)
+        if isinstance(self.tree, TapLeaf):
+            return type(self)(self.tree.derive(*args, **kwargs))
+        left, right = self.tree
+        return type(self)((left.derive(*args, **kwargs), right.derive(*args, **kwargs)))
+
+    def branch(self, *args, **kwargs):
+        if self.tree is None:
+            return type(self)(None)
+        if isinstance(self.tree, TapLeaf):
+            return type(self)(self.tree.branch(*args, **kwargs))
+        left, right = self.tree
+        return type(self)((left.branch(*args, **kwargs), right.branch(*args, **kwargs)))
+
+    def to_public(self, *args, **kwargs):
+        if self.tree is None:
+            return type(self)(None)
+        if isinstance(self.tree, TapLeaf):
+            return type(self)(self.tree.to_public(*args, **kwargs))
+        left, right = self.tree
+        return type(self)((left.to_public(*args, **kwargs),
+                           right.to_public(*args, **kwargs)))
 
     def __str__(self):
         if self.tree is None:
             return ""
-        if isinstance(self.tree, Miniscript):
+        if isinstance(self.tree, TapLeaf):
             return str(self.tree)
         (left, right) = self.tree
         return "{%s,%s}" % (left, right)

--- a/src/embit/liquid/descriptor.py
+++ b/src/embit/liquid/descriptor.py
@@ -1,9 +1,10 @@
+from .. import ec
 from ..descriptor.descriptor import *
 from .networks import NETWORKS
 from .addresses import address
 from . import slip77
 from ..hashes import tagged_hash, sha256
-from ..ec import PrivateKey, PublicKey, secp256k1
+from ..ec import secp256k1
 
 class LDescriptor(Descriptor):
     """Liquid descriptor that supports blinded() wrapper"""
@@ -191,7 +192,7 @@ class MuSigKey(DescriptorBase):
         if self._pubkey is None:
             pubs = [secp256k1.ec_pubkey_parse(k.sec()) for k in self.keys]
             pub = musig_combine_pubs(pubs)
-            self._pubkey = PublicKey(pub)
+            self._pubkey = ec.PublicKey(pub)
         return self._pubkey.sec()
 
 def musig_combine_privs(privs, sort=True):

--- a/src/embit/liquid/transaction.py
+++ b/src/embit/liquid/transaction.py
@@ -1,3 +1,4 @@
+import sys
 import io
 from .. import compact
 from ..script import Script, Witness

--- a/src/embit/script.py
+++ b/src/embit/script.py
@@ -151,8 +151,7 @@ def p2tr(pubkey, script_tree=None):
     if script_tree is None:
         h = b""
     else:
-        raise NotImplementedError("Taproot script trees are not supported yet")
-        _, h = taproot_tree_helper(script_tree)
+        h = script_tree.tweak()
     output_pubkey = pubkey.taproot_tweak(h)
     return Script(b"\x51\x20" + output_pubkey.xonly())
 

--- a/src/embit/transaction.py
+++ b/src/embit/transaction.py
@@ -194,7 +194,14 @@ class Transaction(EmbitBase):
             self._hash_script_pubkeys = hash_script_pubkeys(script_pubkeys)
         return self._hash_script_pubkeys
 
-    def sighash_taproot(self, input_index, script_pubkeys, values, sighash=SIGHASH.DEFAULT):
+    def sighash_taproot(self,
+                        input_index,
+                        script_pubkeys,
+                        values,
+                        sighash=SIGHASH.DEFAULT,
+                        ext_flag=0,
+                        annex_present=False,
+    ):
         """check out bip-341"""
         if input_index < 0 or input_index >= len(self.vin):
             raise TransactionError("Invalid input index")
@@ -213,7 +220,7 @@ class Transaction(EmbitBase):
         if sh not in [SIGHASH.SINGLE, SIGHASH.NONE]:
             h.update(self.hash_outputs())
         # data about this input
-        h.update(b"\x00") # ext_flags and annex are not supported
+        h.update(bytes([2*ext_flag+int(annex_present)]))
         if anyonecanpay:
             h.update(self.vin[input_index].serialize())
             h.update(values[input_index].to_bytes(8, "little"))

--- a/src/embit/transaction.py
+++ b/src/embit/transaction.py
@@ -1,10 +1,9 @@
-import sys
-import io
 import hashlib
 from . import compact
 from .script import Script, Witness
 from . import hashes
 from .base import EmbitBase, EmbitError
+
 
 class TransactionError(EmbitError):
     pass
@@ -200,8 +199,10 @@ class Transaction(EmbitBase):
                         values,
                         sighash=SIGHASH.DEFAULT,
                         ext_flag=0,
-                        annex_present=False,
-                        extra=b"",
+                        annex=None,
+                        script=None,
+                        leaf_version=0xc0,
+                        codeseparator_pos=None,
     ):
         """check out bip-341"""
         if input_index < 0 or input_index >= len(self.vin):
@@ -221,7 +222,7 @@ class Transaction(EmbitBase):
         if sh not in [SIGHASH.SINGLE, SIGHASH.NONE]:
             h.update(self.hash_outputs())
         # data about this input
-        h.update(bytes([2*ext_flag+int(annex_present)]))
+        h.update(bytes([2*ext_flag+int(annex is not None)]))
         if anyonecanpay:
             h.update(self.vin[input_index].serialize())
             h.update(values[input_index].to_bytes(8, "little"))
@@ -229,10 +230,20 @@ class Transaction(EmbitBase):
             h.update(self.vin[input_index].sequence.to_bytes(4, "little"))
         else:
             h.update(input_index.to_bytes(4, "little"))
-        # annex is not supported
+        if annex is not None:
+            h.update(hashes.sha256(compact.to_bytes(len(annex))+annex))
         if sh == SIGHASH.SINGLE:
             h.update(self.vout[input_index].serialize())
-        h.update(extra)
+        if script is not None:
+            h.update(
+                hashes.tagged_hash("TapLeaf", bytes([leaf_version])+script.serialize())
+            )
+            h.update(b"\x00")
+            h.update(
+                b"\xff\xff\xff\xff"
+                if codeseparator_pos is None
+                else codeseparator_pos.to_bytes(4,'little')
+            )
         return h.digest()
 
     def sighash_segwit(self, input_index, script_pubkey, value, sighash=SIGHASH.ALL):

--- a/src/embit/transaction.py
+++ b/src/embit/transaction.py
@@ -201,6 +201,7 @@ class Transaction(EmbitBase):
                         sighash=SIGHASH.DEFAULT,
                         ext_flag=0,
                         annex_present=False,
+                        extra=b"",
     ):
         """check out bip-341"""
         if input_index < 0 or input_index >= len(self.vin):
@@ -231,6 +232,7 @@ class Transaction(EmbitBase):
         # annex is not supported
         if sh == SIGHASH.SINGLE:
             h.update(self.vout[input_index].serialize())
+        h.update(extra)
         return h.digest()
 
     def sighash_segwit(self, input_index, script_pubkey, value, sighash=SIGHASH.ALL):

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -11,6 +11,7 @@ from .test_psbtview import *
 from .test_taproot import *
 from .test_script import *
 from .test_bip85 import *
+from .test_taptree import *
 
 if sys.implementation.name != "micropython":
     from .test_ecdh import *

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -150,6 +150,11 @@ class DescriptorTest(TestCase):
             "[f45912ab/44h/12/32h]xprvA1BtcqnJTKdjRQJ4K2874WTDyPCvgT7bCte7cXi4XrZ5csfoVqgWAL61U9dSf3xE9GUDrFL6RnxPRGvHMn85MHbuKSHDp4vqmJ7PK1Eewug/<*;1>/34h/*",
         ]
         for k in keys:
+            try:
+                Key.from_string(k)
+                print(k)
+            except:
+                pass
             self.assertRaises(
                 Exception,
                 Key.from_string, k

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -47,8 +47,9 @@ class DescriptorTest(TestCase):
             ("wsh(multi(2,%s,%s,%s))" % tuple(keys[:3]), 
              "522103801b3a4e3ca0d61d469445621561c47f6c1424d0fd353a44c2c3ebb84ae78f592103e7d285b4817f83f724cd29394da75dfc84fe639ed147a944e7e6064703b141302103b8fa5d5959fa4027ccbf0736a86ccde4242e3051ea363437b4ff0d52598d7cec53ae"),
 
-            ("wsh(thresh(3,pk(%s),s:pk(%s),s:pk(%s),sdv:older(12960)))" % tuple(keys[:3]), 
-             "2103801b3a4e3ca0d61d469445621561c47f6c1424d0fd353a44c2c3ebb84ae78f59ac7c2103e7d285b4817f83f724cd29394da75dfc84fe639ed147a944e7e6064703b14130ac937c2103b8fa5d5959fa4027ccbf0736a86ccde4242e3051ea363437b4ff0d52598d7cecac937c766302a032b26968935387"),
+            # TODO: invalid miniscript for segwit, but valid for taproot
+            # ("wsh(thresh(3,pk(%s),s:pk(%s),s:pk(%s),sdv:older(12960)))" % tuple(keys[:3]), 
+            #  "2103801b3a4e3ca0d61d469445621561c47f6c1424d0fd353a44c2c3ebb84ae78f59ac7c2103e7d285b4817f83f724cd29394da75dfc84fe639ed147a944e7e6064703b14130ac937c2103b8fa5d5959fa4027ccbf0736a86ccde4242e3051ea363437b4ff0d52598d7cecac937c766302a032b26968935387"),
 
             ("wsh(multi(10,"
                 "0373b665b6fe153c5872de1344339ee60588491257d2c34567aa026af237143a6c,"

--- a/tests/tests/test_liquid.py
+++ b/tests/tests/test_liquid.py
@@ -83,14 +83,14 @@ class LiquidTest(TestCase):
         self.assertEqual(extra, b"")
 
     def test_descriptors(self):
-        multi = "wsh(sortedmulti(1,[12345678/44h/12]xpub6BwcvdstHTJtLpp1WxUiQCYERWSB66XY5JrCpw71GAJxcJ6s2AiUoEK4Nzt6UDaTmanUiSe6TY2RoFturKNLXeWBhwBF6WBNghr8cr7qnjk/{0,1}/*,[abcdef12/84h/22h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/{0,1}/*))"
+        multi = "wsh(sortedmulti(1,[12345678/44h/12]xpub6BwcvdstHTJtLpp1WxUiQCYERWSB66XY5JrCpw71GAJxcJ6s2AiUoEK4Nzt6UDaTmanUiSe6TY2RoFturKNLXeWBhwBF6WBNghr8cr7qnjk/<0;1>/*,[abcdef12/84h/22h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/<0;1>/*))"
         descs = [
-            "wpkh([abcdef12/84h/22h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/{0,1}/*)",
+            "wpkh([abcdef12/84h/22h]xpub6F6wWxm8F64iBHNhyaoh3QKCuuMUY5pfPPr1H1WuZXUXeXtZ21qjFN5ykaqnLL1jtPEFB9d94CyZrcYWKVdSiJKQ6mLGEB5sfrGFBpg6wgA/<0;1>/*)",
             multi,
             "blinded(slip77(L2t59TFgKmc83tPJD1rTy2KxJt44CMMQYsECXdz75xSqVv1X9Tvr),%s)" % multi,
-            "blinded(xprvA18YC5Aog5LxHgMrSv5t9QaHyfh5DU8Pr8zFTP5QhJSTjdg3mSpEyxLZfNQaEc8sALUtsHeDJYsp8YnobhjJT9D7JADoEV4wXiMuNMYDLZ2/{0,1}/*,%s)" % multi,
-            "blinded(musig(xprvA18YC5Aog5LxHgMrSv5t9QaHyfh5DU8Pr8zFTP5QhJSTjdg3mSpEyxLZfNQaEc8sALUtsHeDJYsp8YnobhjJT9D7JADoEV4wXiMuNMYDLZ2/{0,1}/*,xprv9ybbsYg8NKhDxDrSdmWPWih2AVjyDYxvTYvjaqNLmSpQcaLhmXeXUcHDEK99MiPDJwteBF2EzZkhfwwQDycrTgdxWGAgyWVpVJxrgZF5eCT/{0,1}/*),%s)" % multi,
-            "blinded(musig(xpub6E7tbahhWSuFWASKYwctWYX2XhXZcvrFDMurFmV2FdyScS1CJz8VXkf3WchmYnBmC8uMVgENPLYd8uWjXYjxFFwFXD6unhFXs6VBjHTAb9e/{0,1}/*,xprv9ybbsYg8NKhDxDrSdmWPWih2AVjyDYxvTYvjaqNLmSpQcaLhmXeXUcHDEK99MiPDJwteBF2EzZkhfwwQDycrTgdxWGAgyWVpVJxrgZF5eCT/{0,1}/*),%s)" % multi,
+            "blinded(xprvA18YC5Aog5LxHgMrSv5t9QaHyfh5DU8Pr8zFTP5QhJSTjdg3mSpEyxLZfNQaEc8sALUtsHeDJYsp8YnobhjJT9D7JADoEV4wXiMuNMYDLZ2/<0;1>/*,%s)" % multi,
+            "blinded(musig(xprvA18YC5Aog5LxHgMrSv5t9QaHyfh5DU8Pr8zFTP5QhJSTjdg3mSpEyxLZfNQaEc8sALUtsHeDJYsp8YnobhjJT9D7JADoEV4wXiMuNMYDLZ2/<0;1>/*,xprv9ybbsYg8NKhDxDrSdmWPWih2AVjyDYxvTYvjaqNLmSpQcaLhmXeXUcHDEK99MiPDJwteBF2EzZkhfwwQDycrTgdxWGAgyWVpVJxrgZF5eCT/<0;1>/*),%s)" % multi,
+            "blinded(musig(xpub6E7tbahhWSuFWASKYwctWYX2XhXZcvrFDMurFmV2FdyScS1CJz8VXkf3WchmYnBmC8uMVgENPLYd8uWjXYjxFFwFXD6unhFXs6VBjHTAb9e/<0;1>/*,xprv9ybbsYg8NKhDxDrSdmWPWih2AVjyDYxvTYvjaqNLmSpQcaLhmXeXUcHDEK99MiPDJwteBF2EzZkhfwwQDycrTgdxWGAgyWVpVJxrgZF5eCT/<0;1>/*),%s)" % multi,
         ]
         for d in descs:
             desc = LDescriptor.from_string(d)

--- a/tests/tests/test_psbt.py
+++ b/tests/tests/test_psbt.py
@@ -3,7 +3,6 @@
 
 from binascii import hexlify, unhexlify
 from embit.bip32 import HDKey
-from embit.ec import PublicKey
 from embit.psbt import PSBT
 from unittest import TestCase
 

--- a/tests/tests/test_psbtview.py
+++ b/tests/tests/test_psbtview.py
@@ -64,7 +64,7 @@ class PSBTViewTest(TestCase):
     def test_sign(self):
         """Test if we can sign psbtview and get the same as from signing psbt"""
         for compress in [CompressMode.KEEP_ALL, CompressMode.CLEAR_ALL, CompressMode.PARTIAL]:
-            for b64 in PSBTS:
+            for i, b64 in enumerate(PSBTS):
                 psbt = PSBT.from_string(b64, compress=compress)
                 stream = BytesIO(a2b_base64(b64))
                 psbtv = PSBTView.view(stream, compress=compress)
@@ -100,6 +100,10 @@ class PSBTViewTest(TestCase):
                     self.assertEqual(len(signed_inputs), len(psbt.inputs))
                     for i, inp in enumerate(signed_inputs):
                         inp2 = psbt.inputs[i]
+                        if inp.partial_sigs != inp2.partial_sigs:
+                            print(compress)
+                            print(i)
+                            print(inp.partial_sigs, inp2.partial_sigs)
                         self.assertEqual(inp.partial_sigs, inp2.partial_sigs)
                     # check serialization with signatures
                     sigs_stream.seek(0)

--- a/tests/tests/test_taproot.py
+++ b/tests/tests/test_taproot.py
@@ -48,9 +48,32 @@ TAP_PSBTS = [
     "cHNidP8BAH0CAAAAAUAaxszo/duEBuHMtAC7DT2fNdfsnS4wy8vF3hAB/UlJAAAAAAD9////AoCWmAAAAAAAFgAUcCRqeVJZLDGtwLBhaMBPE63W5WnySV0FAAAAACJRIBrRhQ5SjnkT5tE70JEBxp9xkb4uBIHRIzkxac7HP5ZTAAAAAAABASsA4fUFAAAAACJRIFKH/tGO0Q0s2Smklua645o2AiaKUkBJnG3YDvfOcbbVQhXBVTVcqDyXPx2Xzg44Q8hdeJBa8WtNxTG8SI5XIS0jARZUoQdnQp/8bMLMLulMq6QGi4+kememhbEVYTvrM2DmDyMgBB+2r5b0+qaabbiKXfGsCCZ/X5i6EoOa82ErtH5BigCswGIVwVU1XKg8lz8dl84OOEPIXXiQWvFrTcUxvEiOVyEtIwEWFGi48vIp9D+FdjTmg1ubdkSHIVzdfVMACq33siHM79pMxC/7Yq3dbpesX7UJSDHq71fmbAYALaDQdod4fu5JsSMgBgozO1jxe6uPd2hvHYlLTaKei2UIjBpBGIJfyCL/os6swGIVwVU1XKg8lz8dl84OOEPIXXiQWvFrTcUxvEiOVyEtIwEWMbziDCAn/bPsPqCxK0QUbVF34xa8bETwhZ1jFzu+SvNMxC/7Yq3dbpesX7UJSDHq71fmbAYALaDQdod4fu5JsSMgtpzeELVS/INwpBPZEQhNBIUStilyPL6A7W14NH4UZeSswCEWBB+2r5b0+qaabbiKXfGsCCZ/X5i6EoOa82ErtH5BigA5AUzEL/tird1ul6xftQlIMervV+ZsBgAtoNB2h3h+7kmxAgjLd1YAAIABAACAAAAAgAAAAAAAAAAAIRYGCjM7WPF7q493aG8diUtNop6LZQiMGkEYgl/IIv+izjkBMbziDCAn/bPsPqCxK0QUbVF34xa8bETwhZ1jFzu+SvNH/BuhVgAAgAEAAIAAAACAAAAAAAAAAAAhFlU1XKg8lz8dl84OOEPIXXiQWvFrTcUxvEiOVyEtIwEWGQBzxdoKVgAAgAEAAIAAAACAAAAAAAAAAAAhFrac3hC1UvyDcKQT2REITQSFErYpcjy+gO1teDR+FGXkOQEUaLjy8in0P4V2NOaDW5t2RIchXN19UwAKrfeyIczv2vt8HxFWAACAAQAAgAAAAIAAAAAAAAAAAAEXIFU1XKg8lz8dl84OOEPIXXiQWvFrTcUxvEiOVyEtIwEWARggyx1Uf/jQ00tM3UjsFjZveDZgMfHHVAqzX2EeP2HYuVgAAAEFICDrkFAGiwE73j0gTbWaxdsqHHioqiUHP78uetSdBRXGAQZvAcAiIBzPJ1Xc+LktQvZ2DfUHF8ZjLstb2yy8knw6sWGa6npzrALAIiB7XX2FRbhtQQ1OMFHZrKQJgm9Uy11VIkks1y6DlEvafqwCwCIg0OVDwS5pv86EQus8QaNW31/onw7JQJ1aEgD4mu/9Iv2sIQcczydV3Pi5LUL2dg31BxfGYy7LW9ssvJJ8OrFhmup6czkBf88QfvUR3XwjmSYdA3uHV+ve/BhYs0/r70731kheDW8CCMt3VgAAgAEAAIAAAACAAQAAAAEAAAAhByDrkFAGiwE73j0gTbWaxdsqHHioqiUHP78uetSdBRXGGQBzxdoKVgAAgAEAAIAAAACAAQAAAAEAAAAhB3tdfYVFuG1BDU4wUdmspAmCb1TLXVUiSSzXLoOUS9p+OQGzJ3RT0eho23a5cca/2jX8AETEICnTMTP12ajR30czFEf8G6FWAACAAQAAgAAAAIABAAAAAQAAACEH0OVDwS5pv86EQus8QaNW31/onw7JQJ1aEgD4mu/9Iv05ATfGpiWBWMHLfN4FazQuz2SBvTDiVWvd3kqLsLZGpyDW+3wfEVYAAIABAACAAAAAgAEAAAABAAAAAA==",
 ]
 TAP_SIGS = [
-    (unhexlify("6f7f1255071fb5a103b5a4d3e5e295d19e9701e58fa1c457e92733c53ed16804f1036c90f30f6c4753a884c2be8b7d4a7c30a2a86dbfb0e8010bdf7064fd70f7"),),
-    (),
+    (
+        unhexlify("6f7f1255071fb5a103b5a4d3e5e295d19e9701e58fa1c457e92733c53ed16804f1036c90f30f6c4753a884c2be8b7d4a7c30a2a86dbfb0e8010bdf7064fd70f7"), # sig of keyA
+    ),
+    (
+        unhexlify("0574a2735988c4c8bd866ac546ae3f8a29f19a9596742892638c53f3b593269975135f0c58b2db945723e109db4111f6789e2abd37d2de82e94b8af47de63bda"), # A
+    ),
 ]
+# tr(A,{pk(B),and_v(v:pk(C),pk(D))})
+TAPTREE_PSBT = "cHNidP8BAH0CAAAAAeIMcyOBWNnbIqmCIqa0QL9JAwsaDV4HT6+Xv4wJjL17AAAAAAD9////AoCWmAAAAAAAFgAUvSBc5eYHgqHxk7upi3kv5gA/1O3ySV0FAAAAACJRIGNAxXuNUt0BJ6ByFOx9/al93vWen39D6Af7ss1QjlwKAAAAAAABASsA4fUFAAAAACJRIHC7J82blWTnJH9Nl/qeHS97m2KxuBv3L2g58EhgndRRQhXBfy5RDYbr51o4fyQYpNrWWE20ga8PKn5tEtuU8YRHEvhnBFg9xpf/3wPhiU5hrocTD1m9uX9M4MVKhILWLawC70UgUEM1JJofA2CVc9wW77clA2DWZfBnpHMi6GWAVIiEvz2tIK6FHC9E+O2EZBy/b2qVNwJHDf4+QsYN5obNcIcKAP18rMBCFcF/LlENhuvnWjh/JBik2tZYTbSBrw8qfm0S25TxhEcS+J35N4fUhRXmtCF4ZSZhqoN56GqlIBK0Gj/iYJQTJDRCIyBziRZlLMwPXQz69ZgIm6VuAY8hTHxOJrwUh+1pDTGcDazAIRZQQzUkmh8DYJVz3BbvtyUDYNZl8GekcyLoZYBUiIS/PS0Bnfk3h9SFFea0IXhlJmGqg3noaqUgErQaP+JglBMkNELPWtqTAAAAAAAAAAAhFnOJFmUszA9dDPr1mAibpW4BjyFMfE4mvBSH7WkNMZwNLQFnBFg9xpf/3wPhiU5hrocTD1m9uX9M4MVKhILWLawC78xSxyIAAAAAAAAAACEWfy5RDYbr51o4fyQYpNrWWE20ga8PKn5tEtuU8YRHEvgNAHNc6iAAAAAAAAAAACEWroUcL0T47YRkHL9vapU3AkcN/j5Cxg3mhs1whwoA/XwtAZ35N4fUhRXmtCF4ZSZhqoN56GqlIBK0Gj/iYJQTJDRCDAm+LgAAAAAAAAAAARcgfy5RDYbr51o4fyQYpNrWWE20ga8PKn5tEtuU8YRHEvgBGCCUd6Gt2gcmsS/p11C8qpWk79PycyZyAFfM9UNU20W7+wAAAQUg+Du+Rd0qJvYodMsO7j4IVEu8ULoV8jbI1xSbhvot3JEBBmwBwEQgSo5aG71puZDqSiCzIG8zB0pxRZ/Wwkomtl/qpfij37GtIOZJwZtZajmvPLeCviLhGhtqGqLhbezFzxyiqQ9rMrwarAHAIiCKbSCtGMYmKiLS7Ts2At4JPCw1D068SEAP4iuSS1r6pKwhB0qOWhu9abmQ6kogsyBvMwdKcUWf1sJKJrZf6qX4o9+xLQFy0Iqb4ksGrxmHa6MqKmavcuGFR40PfYWk3m4jZLMIHc9a2pMBAAAAAAAAACEHim0grRjGJioi0u07NgLeCTwsNQ9OvEhAD+Irkkta+qQtAd4SDZI0Q0pda4MXoWhUUigZ4oroff9guQq9Mb0CBc4yzFLHIgEAAAAAAAAAIQfmScGbWWo5rzy3gr4i4Robahqi4W3sxc8coqkPazK8Gi0BctCKm+JLBq8Zh2ujKipmr3LhhUeND32FpN5uI2SzCB0MCb4uAQAAAAAAAAAhB/g7vkXdKib2KHTLDu4+CFRLvFC6FfI2yNcUm4b6LdyRDQBzXOogAQAAAAAAAAAA"
+
+TAPTREE_KEYS = [
+    HDKey.from_string(k)
+    for k in [
+        "tprv8ZgxMBicQKsPdiNEPCogjnPGeK4zgUpZGGEP2k2hhiANSpPuUWGVWb6WCQhjSPDn7Nz2u9kq9U1Z1bz6ZVpYL4w3kudYESRMrTprfKzzNyd",
+        "tprv8ZgxMBicQKsPeDCydL6eDyVohN3tLNU4MWrrFBmKkSHUE46mWUQ6YzLAmW57JPiofGLkW2ZCPbtC4NtoKBGWDG9cJhx6d9UhuJdUbFbD36w",
+        "tprv8ZgxMBicQKsPeYcQMuAVda55CQtNHjWQmA33U9XXxPwpnxGHWSe9xoqmJRj4p1AJ8eXDDt82U4vJuvGETigWHYobjXCxpdCqRDsrqdUEpSt",
+        "tprv8ZgxMBicQKsPdabEfXZrBoDe7V2gmahYeASskjJCrpNLoeLuaDq6kzVXbceiQQAoacFDsB7oeek1XinDZy73A6N56z1mKFJv2o7f6EA8Vhn",
+    ]
+]
+TAPTREE_SIGS = [
+    unhexlify("fd2877b89797991d0e237f466a917a5300944f6fb1453b576763ef76e5d1140816d4ec923b36975b859cb744a85286cd0d15a6f7c0ed15f9d03852c7716b3207"), # internal
+    unhexlify("5fd88ed2ce431b003ce2b0e233a3b7870514b130e700b612a4d86fedeb603657ac88e2f4f290ee7ed16e23f6d27f717a5447acdbea5e72d16497a29a4ea46ca6"), # keyA
+    unhexlify("fe9f994315faa9caab4e41d78b0200ca19fd3c735ce7d88e879b0da0b7e1f4dd31f877b6529700f463670f1a6f6ea217f6dfc596cf8c55e78b42b70e3491aac3"), # keyB
+    unhexlify("d09a024358e7f609a0c3dfb94ac852c3f20859784f18911b5ec4cbc8c5ebf4a3642254519b47368fa1b2df75e10c56b77e7f9f34157335c2bc814106e544077c"), # keyC
+]
+
 
 class TaprootTest(TestCase):
     def test_script(self):
@@ -173,10 +196,23 @@ class TaprootTest(TestCase):
             psbt2 = PSBT.from_string(ser)
             assert psbt == psbt2
 
-    def test_sign(self):
-        psbt = PSBT.from_string(TAP_PSBTS[0])
-        psbt.sign_with(KEY_A)
-        self.assertEqual(psbt.inputs[0].final_scriptwitness.items[0], TAP_SIGS[0][0])
+    def test_sign_internal(self):
+        """Test we can sign with internal key"""
+        for b64psbt, sigs in zip(TAP_PSBTS, TAP_SIGS):
+            psbt = PSBT.from_string(b64psbt)
+            psbt.sign_with(KEY_A)
+            self.assertEqual(psbt.inputs[0].final_scriptwitness.items[0], sigs[0])
+
+    def test_sign_taptree(self):
+        """Test we can sign with internal key"""
+        psbt = PSBT.from_string(TAPTREE_PSBT)
+        for key in TAPTREE_KEYS:
+            psbt.sign_with(key)
+        # check internal key signature
+        self.assertEqual(psbt.inputs[0].final_scriptwitness.items[0], TAPTREE_SIGS[0])
+        # check taptree signatures
+        for sig in TAPTREE_SIGS[1:]:
+            self.assertTrue(sig in psbt.inputs[0].taproot_sigs.values())
 
     def test_owns(self):
         d = Descriptor.from_string("tr(%s/86h/1h/0h/{0,1}/*)" % KEY_A)

--- a/tests/tests/test_taproot.py
+++ b/tests/tests/test_taproot.py
@@ -1,5 +1,4 @@
 from unittest import TestCase
-from embit import bip32
 from embit.bip32 import HDKey
 from embit.networks import NETWORKS
 from embit.script import p2tr, address_to_scriptpubkey
@@ -8,9 +7,8 @@ from embit.psbt import DerivationPath, PSBT
 from embit.psbtview import PSBTView
 from embit.ec import SchnorrSig, PublicKey
 from embit.transaction import SIGHASH
-from embit.psbtview import PSBTView
 from io import BytesIO
-from binascii import unhexlify, hexlify
+from binascii import unhexlify
 
 KEY = "tprv8ZgxMBicQKsPf27gmh4DbQqN2K6xnXA7m7AeceqQVGkRYny3X49sgcufzbJcq4k5eaGZDMijccdDzvQga2Saqd78dKqN52QwLyqgY8apX3j"
 ROOT = HDKey.from_string(KEY)

--- a/tests/tests/test_taptree.py
+++ b/tests/tests/test_taptree.py
@@ -65,11 +65,11 @@ ADDRESSES = [
     "tb1pp05sxx74zy3phfpe0e02xg5yal95w35fralsrexwtr2c2k2ae5dqu6shue",
     "tb1pp05sxx74zy3phfpe0e02xg5yal95w35fralsrexwtr2c2k2ae5dqu6shue",
     "tb1pp05sxx74zy3phfpe0e02xg5yal95w35fralsrexwtr2c2k2ae5dqu6shue",
-    None, #"tb1p0k3h2ce3t5r40whug6q8scjlgh2naza2yw2w9gtstr76ct02cffqq2yvst",
-    None, #"tb1pesu98mtyfdjg00fs3hs3gfq5l3vj0fsezm27e5dcgfux7w7hxhssy6xgft",
-    None, #"tb1pjtyykgnzx4yspt06kwqx6vausjf07puezuhryuhypw243484tj3qy2thxw",
-    None, #"tb1pezhhsmppds98a5mjskgwwmucynnq0307lf4l9cwmjxhsnx070nxqc5xnn7",
-    None, #"tb1plueckktz4n872cqk5nskscm2n9f68xtnfuec08ra59knur5dw6kshc3xf9",
+    "tb1p0k3h2ce3t5r40whug6q8scjlgh2naza2yw2w9gtstr76ct02cffqq2yvst",
+    "tb1pesu98mtyfdjg00fs3hs3gfq5l3vj0fsezm27e5dcgfux7w7hxhssy6xgft",
+    "tb1pjtyykgnzx4yspt06kwqx6vausjf07puezuhryuhypw243484tj3qy2thxw",
+    "tb1pezhhsmppds98a5mjskgwwmucynnq0307lf4l9cwmjxhsnx070nxqc5xnn7",
+    "tb1plueckktz4n872cqk5nskscm2n9f68xtnfuec08ra59knur5dw6kshc3xf9",
 ]
 
 # TODO: test that:
@@ -86,6 +86,5 @@ class TapTreeTest(TestCase):
             # check we can convert descriptor back to string the same way
             self.assertEqual(str(desc), d)
             # check address if provided in test case
-            if addr is not None:
-                self.assertEqual(desc.derive(0).address(NETWORK), addr)
+            self.assertEqual(desc.derive(0).address(NETWORK), addr)
 

--- a/tests/tests/test_taptree.py
+++ b/tests/tests/test_taptree.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+from embit.descriptor import Descriptor
+from embit.networks import NETWORKS
+
+NETWORK = NETWORKS['test']
+
+TPRVS = [
+    "tprv8ZgxMBicQKsPerQj6m35no46amfKQdjY7AhLnmatHYXs8S4MTgeZYkWAn4edSGwwL3vkSiiGqSZQrmy5D3P5gBoqgvYP2fCUpBwbKTMTAkL",
+    "tprv8ZgxMBicQKsPd3cbrKjE5GKKJLDEidhtzSSmPVtSPyoHQGL2LZw49yt9foZsN9BeiC5VqRaESUSDV2PS9w7zAVBSK6EQH3CZW9sMKxSKDwD",
+    "tprv8iF7W37EHnVEtDr9EFeyFjQJFL6SfGby2AnZ2vQARxTQHQXy9tdzZvBBVp8a19e5vXhskczLkJ1AZjqgScqWL4FpmXVp8LLjiorcrFK63Sr",
+]
+TPUBS = [
+    "tpubD6NzVbkrYhZ4YPAbyf6urxqqnmJF79PzQtyERAmvkSVS9fweCTjxjDh22Z5St9fGb1a5DUCv8G27nYupKP1Ctr1pkamJossoetzws1moNRn",
+    "tpubD6NzVbkrYhZ4YMQC15JS7QcrsAyfGrGiykweqMmPxTkEVScu7vCZLNpPXW1XphHwzsgmqdHWDQAfucbM72EEB1ZEyfgZxYvkZjYVXx1xS9p",
+    "tpubD6NzVbkrYhZ4YU9vM1s53UhD75UyJatx8EMzMZ3VUjR2FciNfLLkAw6a4pWACChzobTseNqdWk4G7ZdBqRDLtLSACKykTScmqibb1ZrCvJu",
+    "tpubD6NzVbkrYhZ4XRMcMFMMFvzVt6jaDAtjZhD7JLwdPdMm9xa76DnxYYP7w9TZGJDVFkek3ArwVsuacheqqPog8TH5iBCX1wuig8PLXim4n9a",
+    "tpubD6NzVbkrYhZ4WsqRzDmkL82SWcu42JzUvKWzrJHQ8EC2vEHRHkXj1De93sD3biLrKd8XGnamXURGjMbYavbszVDXpjXV2cGUERucLJkE6cy",
+    "tpubDEFLeBkKTm8aiYkySz8hXAXPVnPSfxMi7Fxhg9sejUrkwJuRWvPdLEiXjTDbhGbjLKCZUDUUibLxTnK5UP1q7qYrSnPqnNe7M8mvAW1STcc",
+    "tpubD6NzVbkrYhZ4WR99ygpiJvPMAJiwahjLgGywc5vJx2gUfKUfEPCrbKmQczDPJZmLcyZzRb5Ti6rfUb89S2WFyPH7FDtD6RFDA1hdgTEgEUL",
+]
+PUBKEYS = [
+    "02aebf2d10b040eb936a6f02f44ee82f8b34f5c1ccb20ff3949c2b28206b7c1068",
+    "030f64b922aee2fd597f104bc6cb3b670f1ca2c6c49b1071a1a6c010575d94fe5a",
+    "02abe475b199ec3d62fa576faee16a334fdb86ffb26dce75becebaaedf328ac3fe",
+    "0314f3dc33595b0d016bb522f6fe3a67680723d842c1b9b8ae6b59fdd8ab5cccb4",
+    "025eba3305bd3c829e4e1551aac7358e4178832c739e4fc4729effe428de0398ab",
+    "029ffbe722b147f3035c87cb1c60b9a5947dd49c774cc31e94773478711a929ac0",
+    "0211c7b2e18b6fd330f322de087da62da92ae2ae3d0b7cec7e616479cce175f183",
+]
+
+P2WSH_MINISCRIPTS = [
+    # One of two keys
+    "or_b(pk(%s/*),s:pk(%s/*))" % (TPUBS[0], TPUBS[1]),
+    # A script similar (same spending policy) to BOLT3's offered HTLC (with anchor outputs)
+    "or_d(pk(%s/*),and_v(and_v(v:pk(%s/*),or_c(pk(%s/*),v:hash160(7f999c905d5e35cefd0a37673f746eb13fba3640))),older(1)))" % (TPUBS[0], TPUBS[1], TPUBS[2]),
+    # A Revault Unvault policy with the older() replaced by an after()
+    "andor(multi(2,%s/*,%s/*),and_v(v:multi(4,%s,%s,%s,%s),after(424242)),thresh(4,pkh(%s/*),a:pkh(%s/*),a:pkh(%s/*),a:pkh(%s/*)))" % (TPUBS[0], TPUBS[1], PUBKEYS[0], PUBKEYS[1], PUBKEYS[2], PUBKEYS[3], TPUBS[2], TPUBS[3], TPUBS[4], TPUBS[5]),
+    # Liquid-like federated pegin with emergency recovery keys
+    "or_i(and_b(pk(%s),a:and_b(pk(%s),a:and_b(pk(%s),a:and_b(pk(%s),s:pk(%s))))),and_v(v:thresh(2,pkh(%s/*),a:pkh(%s),a:pkh(%s)),older(4209713)))" % (PUBKEYS[0], PUBKEYS[1], PUBKEYS[2], PUBKEYS[3], PUBKEYS[4], TPUBS[0], PUBKEYS[5], PUBKEYS[6]),
+]
+
+DESCS = ["wsh(%s)" % ms for ms in P2WSH_MINISCRIPTS] + [
+    # one pubkey in taptree
+    "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,pk(%s))" % PUBKEYS[0],
+    # A Taproot with one of the above scripts as the single script path.
+    "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,%s)" % P2WSH_MINISCRIPTS[0],
+    # A Taproot with two script paths among the above scripts.
+    "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{%s,%s})" % (P2WSH_MINISCRIPTS[0], P2WSH_MINISCRIPTS[1]),
+    # A Taproot with three script paths among the above scripts.
+    "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{%s,%s},%s})" % (P2WSH_MINISCRIPTS[0], P2WSH_MINISCRIPTS[1], P2WSH_MINISCRIPTS[2].replace("multi", "multi_a")),
+    # A Taproot with all above scripts in its tree.
+    "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,{{%s,%s},{%s,%s}})"% (P2WSH_MINISCRIPTS[0], P2WSH_MINISCRIPTS[1], P2WSH_MINISCRIPTS[2].replace("multi", "multi_a"), P2WSH_MINISCRIPTS[3]),
+]
+
+# expected addresses for all descriptors with derivation index 0
+ADDRESSES = [
+    "tb1qfxrnzaaa2f3na8tsv7up4ntm87ypdvmhmgyvf9glceft08zxquds4e4nkh",
+    "tb1q7j0nx23h9gpgm2gf9zzkg9dg49jrqq0f9lhnzxtxzf3wwqe9943svq9s03",
+    "tb1qr9yt77ej508pj723egt2sprxz32r7pvs5glg0jg32xxl83sfm3sqwlttzn",
+    "tb1qrgwwjs3n69znlq9z254fmx28hyamhwqjcuu5vfnyklvje5v4rjdqxzefdr",
+    None, #"tb1p0k3h2ce3t5r40whug6q8scjlgh2naza2yw2w9gtstr76ct02cffqq2yvst",
+    None, #"tb1pesu98mtyfdjg00fs3hs3gfq5l3vj0fsezm27e5dcgfux7w7hxhssy6xgft",
+    None, #"tb1pjtyykgnzx4yspt06kwqx6vausjf07puezuhryuhypw243484tj3qy2thxw",
+    None, #"tb1pezhhsmppds98a5mjskgwwmucynnq0307lf4l9cwmjxhsnx070nxqc5xnn7",
+    None, #"tb1plueckktz4n872cqk5nskscm2n9f68xtnfuec08ra59knur5dw6kshc3xf9",
+]
+
+# TODO: test that:
+# - xonly pubkey can be only used in taproot descriptors
+# - sec pubkeys or xpubs can be used in taproot as root key
+# - p2tr accepts empty pubkey if taptree is set
+# - multi and sortedmulti can't be used in taproot
+# - multi_a can't be used outside of taproot
+
+class TapTreeTest(TestCase):
+    def test_addresses(self):
+        for d, addr in zip(DESCS, ADDRESSES):
+            if addr is not None:
+                self.assertEqual(Descriptor.from_string(d).derive(0).address(NETWORK), addr)
+

--- a/tests/tests/test_taptree.py
+++ b/tests/tests/test_taptree.py
@@ -40,6 +40,10 @@ P2WSH_MINISCRIPTS = [
 ]
 
 DESCS = ["wsh(%s)" % ms for ms in P2WSH_MINISCRIPTS] + [
+    # one key only
+    "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768)",
+    "tr(024d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768)",
+    "tr(034d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768)",
     # one pubkey in taptree
     "tr(4d54bb9928a0683b7e383de72943b214b0716f58aa54c7ba6bcea2328bc9c768,pk(%s))" % PUBKEYS[0],
     # A Taproot with one of the above scripts as the single script path.
@@ -58,6 +62,9 @@ ADDRESSES = [
     "tb1q7j0nx23h9gpgm2gf9zzkg9dg49jrqq0f9lhnzxtxzf3wwqe9943svq9s03",
     "tb1qr9yt77ej508pj723egt2sprxz32r7pvs5glg0jg32xxl83sfm3sqwlttzn",
     "tb1qrgwwjs3n69znlq9z254fmx28hyamhwqjcuu5vfnyklvje5v4rjdqxzefdr",
+    "tb1pp05sxx74zy3phfpe0e02xg5yal95w35fralsrexwtr2c2k2ae5dqu6shue",
+    "tb1pp05sxx74zy3phfpe0e02xg5yal95w35fralsrexwtr2c2k2ae5dqu6shue",
+    "tb1pp05sxx74zy3phfpe0e02xg5yal95w35fralsrexwtr2c2k2ae5dqu6shue",
     None, #"tb1p0k3h2ce3t5r40whug6q8scjlgh2naza2yw2w9gtstr76ct02cffqq2yvst",
     None, #"tb1pesu98mtyfdjg00fs3hs3gfq5l3vj0fsezm27e5dcgfux7w7hxhssy6xgft",
     None, #"tb1pjtyykgnzx4yspt06kwqx6vausjf07puezuhryuhypw243484tj3qy2thxw",
@@ -75,6 +82,10 @@ ADDRESSES = [
 class TapTreeTest(TestCase):
     def test_addresses(self):
         for d, addr in zip(DESCS, ADDRESSES):
+            desc = Descriptor.from_string(d)
+            # check we can convert descriptor back to string the same way
+            self.assertEqual(str(desc), d)
+            # check address if provided in test case
             if addr is not None:
-                self.assertEqual(Descriptor.from_string(d).derive(0).address(NETWORK), addr)
+                self.assertEqual(desc.derive(0).address(NETWORK), addr)
 


### PR DESCRIPTION
This PR is work in progress.

Plan:
- [x] parse taptree descriptors like `tr(k1,{miniscriptA,{miniscriptB,miniscriptC}})`
- [x] generate addresses (see `tests/test_taptree.py`)
- [x] psbt signing support for taptree keys
- [x] moar tests, including integration tests with Bitcoin Core

To generate addresses from taproot descriptors I used [rust-miniscript](https://github.com/rust-bitcoin/rust-miniscript). For simple tests one can use [miniscript.fun](https://miniscript.fun/#/full/eyJpZCI6ImRlbW9AMC4xLjAiLCJub2RlcyI6eyI3Ijp7ImlkIjo3LCJkYXRhIjp7ImlkeCI6MCwiZGVzYyI6InRyKDAyNGQ1NGJiOTkyOGEwNjgzYjdlMzgzZGU3Mjk0M2IyMTRiMDcxNmY1OGFhNTRjN2JhNmJjZWEyMzI4YmM5Yzc2OCxwaygwMmFlYmYyZDEwYjA0MGViOTM2YTZmMDJmNDRlZTgyZjhiMzRmNWMxY2NiMjBmZjM5NDljMmIyODIwNmI3YzEwNjgpKSJ9LCJpbnB1dHMiOnsiZGVzYyI6eyJjb25uZWN0aW9ucyI6W119fSwib3V0cHV0cyI6eyJhZGRyIjp7ImNvbm5lY3Rpb25zIjpbXX19LCJwb3NpdGlvbiI6WzM1Mi4wMjUzNzcyMzI1MDMxNiwyMDguNzM0MTY1OTg4OTAwNjhdLCJuYW1lIjoiQWRkcmVzcyJ9fSwiY29tbWVudHMiOltdLCJuZXR3b3JrIjoidGVzdG5ldCJ9) and enter a valid taproot descriptor as an input for address node.