### PR TITLE
add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+#IntelliJ
+.idea/


### PR DESCRIPTION
.idea/ is the project folder for IntelliJ IDEs (Pycharm, Clion, etc...)