### PR TITLE
don't rely on miniscript.NAME

### DIFF
--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -3,7 +3,7 @@ from .. import script
 from ..networks import NETWORKS
 from .errors import DescriptorError
 from .base import DescriptorBase
-from .miniscript import Miniscript, Multi, Sortedmulti, SortedmultiA
+from .miniscript import Miniscript, Multi, Sortedmulti
 from .arguments import Key
 from .taptree import TapTree
 

--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -98,7 +98,6 @@ class Descriptor(DescriptorBase):
 
     @property
     def is_segwit(self):
-        # TODO: is taproot segwit?
         return (
             (self.wsh and self.miniscript) or (self.wpkh and self.key) or self.taproot
         )
@@ -112,16 +111,14 @@ class Descriptor(DescriptorBase):
         return self.taproot
 
     @property
-    def is_basic_multisig(self):
-        # all Multi, Sortedmulti, MultiA, SortedmultiA inherit from Multi
-        return self.miniscript and isinstance(self.miniscript, Multi)
+    def is_basic_multisig(self) -> bool:
+        # TODO: should be true for taproot basic multisig with NUMS as internal key
+        # Sortedmulti is subclass of Multi
+        return bool(self.miniscript and isinstance(self.miniscript, Multi))
 
     @property
-    def is_sorted(self):
-        return self.is_basic_multisig and (
-            isinstance(self.miniscript, Sortedmulti)
-            or isinstance(self.miniscript, SortedmultiA)
-        )
+    def is_sorted(self) -> bool:
+        return bool(self.is_basic_multisig and isinstance(self.miniscript, Sortedmulti))
 
     def scriptpubkey_type(self):
         if self.is_taproot:

--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -3,7 +3,7 @@ from .. import script
 from ..networks import NETWORKS
 from .errors import DescriptorError
 from .base import DescriptorBase
-from .miniscript import Miniscript
+from .miniscript import Miniscript, Multi, Sortedmulti, SortedmultiA
 from .arguments import Key
 from .taptree import TapTree
 
@@ -113,11 +113,15 @@ class Descriptor(DescriptorBase):
 
     @property
     def is_basic_multisig(self):
-        return self.miniscript and self.miniscript.NAME in ["multi", "sortedmulti"]
+        # all Multi, Sortedmulti, MultiA, SortedmultiA inherit from Multi
+        return self.miniscript and isinstance(self.miniscript, Multi)
 
     @property
     def is_sorted(self):
-        return self.is_basic_multisig and self.miniscript.NAME == "sortedmulti"
+        return self.is_basic_multisig and (
+            isinstance(self.miniscript, Sortedmulti)
+            or isinstance(self.miniscript, SortedmultiA)
+        )
 
     def scriptpubkey_type(self):
         if self.is_taproot:

--- a/src/embit/ec.py
+++ b/src/embit/ec.py
@@ -209,6 +209,10 @@ class PrivateKey(EmbitKey):
     def get_public_key(self) -> PublicKey:
         return PublicKey(secp256k1.ec_pubkey_create(self._secret), self.compressed)
 
+    def to_public(self) -> PublicKey:
+        """Alias to get_public_key for API consistency"""
+        return self.get_public_key()
+
     def sign(self, msg_hash, grind=True) -> Signature:
         sig = Signature(secp256k1.ecdsa_sign(msg_hash, self._secret))
         if grind:

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -2,8 +2,9 @@ from unittest import TestCase
 from binascii import hexlify
 from embit.descriptor import Descriptor, Key
 from embit.descriptor.arguments import KeyHash, Number
-from embit.descriptor.miniscript import OPERATORS, WRAPPERS
+from embit.descriptor.miniscript import OPERATORS, WRAPPERS, Miniscript
 from embit.descriptor.checksum import add_checksum, DescriptorError
+from embit import ec
 
 
 class DescriptorTest(TestCase):
@@ -208,6 +209,41 @@ class DescriptorTest(TestCase):
         for wr in WRAPPERS:
             w = wr(o)
             self.assertEqual(len(w), len(w.compile()))
+
+    def test_multisig(self):
+        keys = tuple([ec.PrivateKey(bytes([i + 1] * 32)).to_public() for i in range(4)])
+        miniscripts = [
+            # descriptor: str, is_basic_multisig: bool, is_sorted: bool
+            (
+                "c:andor(multi(1,%s,%s),pk_k(%s),pk_k(%s))" % keys,
+                False,
+                False,
+            ),
+            (
+                "multi(2,%s,%s,%s,%s)" % keys,
+                True,
+                False,
+            ),
+            (
+                "multi_a(2,%s,%s,%s,%s)" % keys,
+                True,
+                False,
+            ),
+            (
+                "sortedmulti(2,%s,%s,%s,%s)" % keys,
+                True,
+                True,
+            ),
+            (
+                "sortedmulti_a(2,%s,%s,%s,%s)" % keys,
+                True,
+                True,
+            ),
+        ]
+        for m, is_basic, is_sorted in miniscripts:
+            d = Descriptor.from_string("wsh(%s)" % m)
+            self.assertEqual(d.is_basic_multisig, is_basic)
+            self.assertEqual(d.is_sorted, is_sorted)
 
 
 # test that:

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 from binascii import hexlify
 from embit.descriptor import Descriptor, Key
 from embit.descriptor.arguments import KeyHash, Number
-from embit.descriptor.miniscript import OPERATORS, WRAPPERS, Miniscript
+from embit.descriptor.miniscript import OPERATORS, WRAPPERS
 from embit.descriptor.checksum import add_checksum, DescriptorError
 from embit import ec
 

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -212,36 +212,36 @@ class DescriptorTest(TestCase):
 
     def test_multisig(self):
         keys = tuple([ec.PrivateKey(bytes([i + 1] * 32)).to_public() for i in range(4)])
-        miniscripts = [
+        descriptors = [
             # descriptor: str, is_basic_multisig: bool, is_sorted: bool
             (
-                "c:andor(multi(1,%s,%s),pk_k(%s),pk_k(%s))" % keys,
+                "wsh(c:andor(multi(1,%s,%s),pk_k(%s),pk_k(%s)))" % keys,
                 False,
                 False,
             ),
             (
-                "multi(2,%s,%s,%s,%s)" % keys,
+                "wsh(multi(2,%s,%s,%s,%s))" % keys,
                 True,
                 False,
             ),
             (
-                "multi_a(2,%s,%s,%s,%s)" % keys,
+                "wsh(sortedmulti(2,%s,%s,%s,%s))" % keys,
                 True,
+                True,
+            ),
+            (
+                "tr(%s,multi_a(2,%s,%s,%s))" % keys,
+                False,
                 False,
             ),
             (
-                "sortedmulti(2,%s,%s,%s,%s)" % keys,
-                True,
-                True,
-            ),
-            (
-                "sortedmulti_a(2,%s,%s,%s,%s)" % keys,
-                True,
-                True,
+                "tr(%s,sortedmulti_a(2,%s,%s,%s))" % keys,
+                False,
+                False,
             ),
         ]
-        for m, is_basic, is_sorted in miniscripts:
-            d = Descriptor.from_string("wsh(%s)" % m)
+        for dstr, is_basic, is_sorted in descriptors:
+            d = Descriptor.from_string(dstr)
             self.assertEqual(d.is_basic_multisig, is_basic)
             self.assertEqual(d.is_sorted, is_sorted)
 


### PR DESCRIPTION
Relevant issue: https://github.com/cryptoadvance/specter-diy/issues/259