### PR TITLE
tests/test_slip39: update test vectors reference implementation link

### DIFF
--- a/tests/tests/test_slip39.py
+++ b/tests/tests/test_slip39.py
@@ -1,5 +1,6 @@
-# BIP32 test vectors adapted from the reference implementation:
-# https://github.com/trezor/python-mnemonic/blob/master/test_mnemonic.py
+# SLIP-0039 test vectors adapted from the reference implementation:
+# https://github.com/trezor/python-shamir-mnemonic/blob/master/test_shamir.py
+# https://github.com/trezor/python-shamir-mnemonic/blob/master/vectors.json
 
 from binascii import hexlify, unhexlify
 from embit.bip32 import HDKey


### PR DESCRIPTION
By unknown reason link points to BIP32, but this file has nothing in common with it. In fact test vectors are from SLIP39 reference implementation [1]. 

[1] https://github.com/satoshilabs/slips/blob/master/slip-0039.md#reference-implementation