### PR TITLE
Make code compatible with micropython mpy-cross compiler

### DIFF
--- a/src/embit/util/ctypes_secp256k1.py
+++ b/src/embit/util/ctypes_secp256k1.py
@@ -891,7 +891,7 @@ def pedersen_commit(vbf, value, gen, context=_secp.ctx):
     if len(gen) != 64:
         raise ValueError("Generator should be 64 bytes long")
     if len(vbf) != 32:
-        raise ValueError(f"Blinding factor should be 32 bytes long, not {len(vbf)}")
+        raise ValueError("Blinding factor should be 32 bytes long, not {}".format(len(vbf)))
     commit = bytes(64)
     r = _secp.secp256k1_pedersen_commit(context, commit, vbf, value, gen)
     if r == 0:
@@ -908,7 +908,7 @@ def pedersen_blind_generator_blind_sum(
     p = c_char_p(vbf)  # obtain a pointer of various types
     address = cast(p, c_void_p).value
 
-    vbfs_joined = (c_char_p * len(vbfs))(*vbfs[:-1], address)
+    vbfs_joined = (c_char_p * len(vbfs))(*(vbfs[:-1] + [address]))
     gens_joined = (c_char_p * len(gens))(*gens)
     res = _secp.secp256k1_pedersen_blind_generator_blind_sum(
         context, vals, gens_joined, vbfs_joined, len(values), num_inputs

--- a/src/embit/util/py_ripemd160.py
+++ b/src/embit/util/py_ripemd160.py
@@ -396,12 +396,14 @@ def ripemd160(data):
     state = (0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0)
     # Process full 64-byte blocks in the input.
     for b in range(len(data) >> 6):
-        state = compress(*state, data[64 * b : 64 * (b + 1)])
+        a, b, c, d, e = state  # Unpack state into individual variables
+        state = compress(a, b, c, d, e, data[64 * b : 64 * (b + 1)])
     # Construct final blocks (with padding and size).
     pad = b"\x80" + b"\x00" * ((119 - len(data)) & 63)
     fin = data[len(data) & ~63 :] + pad + (8 * len(data)).to_bytes(8, "little")
     # Process final blocks.
     for b in range(len(fin) >> 6):
-        state = compress(*state, fin[64 * b : 64 * (b + 1)])
+        a, b, c, d, e = state  # Unpack state into individual variables
+        state = compress(a, b, c, d, e, fin[64 * b : 64 * (b + 1)])
     # Produce output.
     return b"".join((h & 0xFFFFFFFF).to_bytes(4, "little") for h in state)


### PR DESCRIPTION
Please see this PR as a question:
I'm experimenting with mpy-cross compiler to "freeze" python code into firmware binaries in Krux project.
To be able to cross-compile Embit I had to simplify and split some instructions to make them compatible with our Micropython version (1.11). Even if this changes are not of interest of Embit, can you review them and check if they don't cause any issue?
We don't use `ctypes_secp256k1.py` on Krux (we use C version) but `py_ripemd160.py` is used