### PR TITLE
Fix Incompatible Syntax for Cross-Compiling with mpy-cross v1.11

### DIFF
--- a/src/embit/util/py_ripemd160.py
+++ b/src/embit/util/py_ripemd160.py
@@ -396,12 +396,14 @@ def ripemd160(data):
     state = (0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0)
     # Process full 64-byte blocks in the input.
     for b in range(len(data) >> 6):
-        state = compress(*state, data[64 * b : 64 * (b + 1)])
+        s1, s2, s3, s4, s5 = state  # Unpack state into individual variables
+        state = compress(s1, s2, s3, s4, s5, data[64 * b: 64 * (b + 1)])
     # Construct final blocks (with padding and size).
     pad = b"\x80" + b"\x00" * ((119 - len(data)) & 63)
-    fin = data[len(data) & ~63 :] + pad + (8 * len(data)).to_bytes(8, "little")
+    fin = data[len(data) & ~63:] + pad + (8 * len(data)).to_bytes(8, "little")
     # Process final blocks.
     for b in range(len(fin) >> 6):
-        state = compress(*state, fin[64 * b : 64 * (b + 1)])
+        s1, s2, s3, s4, s5 = state  # Unpack state into individual variables
+        state = compress(s1, s2, s3, s4, s5, fin[64 * b: 64 * (b + 1)])
     # Produce output.
     return b"".join((h & 0xFFFFFFFF).to_bytes(4, "little") for h in state)

--- a/src/embit/util/py_ripemd160.py
+++ b/src/embit/util/py_ripemd160.py
@@ -397,13 +397,13 @@ def ripemd160(data):
     # Process full 64-byte blocks in the input.
     for b in range(len(data) >> 6):
         s1, s2, s3, s4, s5 = state  # Unpack state into individual variables
-        state = compress(s1, s2, s3, s4, s5, data[64 * b: 64 * (b + 1)])
+        state = compress(s1, s2, s3, s4, s5, data[64 * b : 64 * (b + 1)])
     # Construct final blocks (with padding and size).
     pad = b"\x80" + b"\x00" * ((119 - len(data)) & 63)
-    fin = data[len(data) & ~63:] + pad + (8 * len(data)).to_bytes(8, "little")
+    fin = data[len(data) & ~63 :] + pad + (8 * len(data)).to_bytes(8, "little")
     # Process final blocks.
     for b in range(len(fin) >> 6):
         s1, s2, s3, s4, s5 = state  # Unpack state into individual variables
-        state = compress(s1, s2, s3, s4, s5, fin[64 * b: 64 * (b + 1)])
+        state = compress(s1, s2, s3, s4, s5, fin[64 * b : 64 * (b + 1)])
     # Produce output.
     return b"".join((h & 0xFFFFFFFF).to_bytes(4, "little") for h in state)


### PR DESCRIPTION
I've been experimenting with cross-compiling MicroPython code in Krux using the mpy-cross tool and encountered issues compiling Embit due to some incompatible syntaxes. I discovered that the issue is only present in our deprecated MicroPython distribution, V1.11. Version 1.22 of mpy-cross works seamlessly with Embit.

The change this PR contains is specifically for compatibility with our older MicroPython distribution (V1.11) and has no impact on updated versions of MicroPython. However, it would be beneficial for us to avoid forking Embit just for this minor adjustment. Please consider merging this change into the main repository. If there are any concerns or if you think this is not a suitable modification, please let me know if it could create any issues.

P.S.: I made a hasty PR before this one with an error, but @jdlcdl caught it, helped me fix it, and run tests. Thanks, Jean!