### PR TITLE
Refactor Nested Segwit descriptor parsing for Android compatibility

### DIFF
--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -315,7 +315,7 @@ class Descriptor(DescriptorBase):
             is_miniscript = False
             sh = True
             wpkh = True
-            assert s.read(1) == b"("
+            s.seek(1, 1)
         elif start.startswith(b"wpkh("):
             is_miniscript = False
             wpkh = True


### PR DESCRIPTION
While integrating Nested Segwit into the Krux app, I discovered that parsing `sh(wpkh(` descriptors in Android (Kivy-Python) did not advance the stream pointer using `assert s.read(1) == b"("`, leading to descriptor parsing and loading failure. I circumvented this by substituting the code line with a `seek` command, which moved the pointer but skipped the check for the "(" byte, so maybe there's a better approach for this.
The aim of this tiny pull request is to maintain the elegance of executing identical Embit code across various platforms, including MicroPython, desktop operating systems, and Android.