### PR TITLE
Limit bip39 mnemonic

### DIFF
--- a/src/embit/bip39.py
+++ b/src/embit/bip39.py
@@ -11,7 +11,7 @@ def mnemonic_to_bytes(mnemonic: str, ignore_checksum: bool = False, wordlist=WOR
     # this function is copied from Jimmy Song's HDPrivateKey.from_mnemonic() method
 
     words = mnemonic.strip().split()
-    if len(words) % 3 != 0 or len(words) < 12:
+    if len(words) % 3 != 0 or not 12 <= len(words) <= 24:
         raise ValueError("Invalid recovery phrase")
 
     binary_seed = bytearray()
@@ -97,7 +97,7 @@ def _extract_index(bits, b, n):
 
 
 def mnemonic_from_bytes(entropy, wordlist=WORDLIST):
-    if len(entropy) % 4 != 0:
+    if len(entropy) % 4 != 0 or not 16 <= len(entropy) <= 32:
         raise ValueError("Byte array should be multiple of 4 long (16, 20, ..., 32)")
     total_bits = len(entropy) * 8
     checksum_bits = total_bits // 32

--- a/tests/tests/test_bip39.py
+++ b/tests/tests/test_bip39.py
@@ -173,8 +173,24 @@ class Bip39Test(TestCase):
             self.assertEqual(act_xkey.to_base58(), xprv)
 
     def test_invalid_length(self):
-        words = "panel trumpet seek bridge income piano history car flower aim loan accident embark canoe"
-        self.assertFalse(mnemonic_is_valid(words))
+        invalid_length = [
+            # not divisible by 3, too short, too long
+            "panel trumpet seek bridge income piano history car flower aim loan accident embark canoe",
+            "zoo " * 8 + "zebra",
+            "zoo " * 26 + "valley",
+        ]
+        for words in invalid_length:
+            self.assertFalse(mnemonic_is_valid(words))
+            self.assertRaises(ValueError, mnemonic_to_bytes, words)
+
+        invalid_length = [
+            # not divisible by 4, too short, too long
+            b"\x00" * 19,
+            b"\x00" * 12,
+            b"\x00" * 36,
+        ]
+        for entropy in invalid_length:
+            self.assertRaises(ValueError, mnemonic_from_bytes, entropy)
 
     def test_invalid_word(self):
         words = "fljsafk minute glow ride mask ceiling old limb rookie discover cotton biology"


### PR DESCRIPTION
### Purpose

To limit embit.bip39's mnemonic length to 24 words, entropy length to 128 - 256 bits, as defined in:

https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic


### Changes

This pull-request changes:
* src/embit/bip39.py:
  * extending an existing condition in mnemonic_to_bytes() to limit: 12 <= len(mnemonic) <= 24 words,
  * extending an existing condition in mnemonic_from_bytes() to limit: 16 <= len(entropy) <= 32 bytes.
* tests/tests/test_bip39.py
  * extending existing test_invalid_length() to test mnemonic-words and entropy-bytes lengths.

Note: while this could break 3rd party apps that previously exploited this "feature", calling `mnemonic_to_seed()` with `wordlist=None` would still allow recovery of bip32 wallets from non-standard bip39 mnemonics.  Only encoding/decoding and their internal validation of input length has changed.

### Example of non-standard embit.bip39 mis-use

Not that anyone should actually use embit.bip39 in the following manner, but so that they cannot --
unless it is intended that the following code snippet succeed:
```python
from embit import bip39, bip32

mnemonic = 'estate simple blush security shoulder recipe ridge catch half argue siege seat all cruise six hub call indoor forget ski scheme caution spatial unveil cake just fresh food crazy rack remind easily apart hint elite shadow bitter dash oval slow call drink fresh dolphin bamboo defy night hospital hover canal breeze security stone noodle circle company cherry october battle food barrel route remain pizza impulse icon little paddle lizard awake cause assault hunt rebel elite trip velvet crawl magic lottery harvest patient bone under fire develop light method junior gate motion system dragon cruise obtain august hunt poverty blue traffic rare cute nest auction half simple banner excite short awake snow connect clown faith success turtle curve mother differ hockey gesture much battle seed north ribbon like around industry adapt elite uphold bleak noodle citizen unfold inner donate blush food version render remember toss grunt hidden mercy seat tragic stomach express beef use'

# True, but it's an invalid bip39 mnemonic -- too long
assert len(mnemonic.split()) == 153

# this should fail -- AssertionError
assert bip39.mnemonic_is_valid(mnemonic)

# these should fail -- ValueError("Invalid recovery phrase")
assert bip39.mnemonic_from_bytes(bip39.mnemonic_to_bytes(mnemonic)) == mnemonic

assert str(bip32.HDKey.from_seed(bip39.mnemonic_to_seed(mnemonic))) == 'xprv9s21ZrQH143K3KfRKeNCLeDVTJzTPoRwMC5yh25en6WDZeBMddPbTb87vvMi8n1yipUhYYNEoGMbMzF6vcw3oCu5ttPT3RiwYSUJqYWJ2yC' 

assert str(bip32.HDKey.from_seed(bip39.mnemonic_to_seed(mnemonic)).to_public()) == 'xpub661MyMwAqRbcFojtRfuChnAE1LpwoG9niR1aVQVGLS3CSSWWBAhr1PSbn9gW9GkTdaMsBHSv5fTeAXgZn6qMCTR3MLf3PwLceUUiLkgeohr'
```