### PR TITLE
sighash_taproot algorithm fixes

### DIFF
--- a/src/embit/transaction.py
+++ b/src/embit/transaction.py
@@ -233,7 +233,8 @@ class Transaction(EmbitBase):
         # data about this input
         h.update(bytes([2 * ext_flag + int(annex is not None)]))
         if anyonecanpay:
-            h.update(self.vin[input_index].serialize())
+            h.update(bytes(reversed(self.vin[input_index].txid)))
+            h.update(self.vin[input_index].vout.to_bytes(4, "little"))
             h.update(values[input_index].to_bytes(8, "little"))
             h.update(script_pubkeys[input_index].serialize())
             h.update(self.vin[input_index].sequence.to_bytes(4, "little"))
@@ -242,7 +243,7 @@ class Transaction(EmbitBase):
         if annex is not None:
             h.update(hashes.sha256(compact.to_bytes(len(annex)) + annex))
         if sh == SIGHASH.SINGLE:
-            h.update(self.vout[input_index].serialize())
+            h.update(hashes.sha256(self.vout[input_index].serialize()))
         if script is not None:
             h.update(
                 hashes.tagged_hash(


### PR DESCRIPTION
Fixes #65 

I've found 2 distinct bugs in the implementation of the [signature validation rules from BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#signature-validation-rules).

The first, when the sighash includes ANYONECANPAY the spec says the first chunk of data must be `outpoint (36): the COutPoint of this input (32-byte hash + 4-byte little-endian)`. However Embit was serializing the whole input using the `TransactionInput.write_to()` method, which includes more fields and results in 41 bytes of data instead of 36.

Second, when SIGHASH_SINGLE is used the spec says to include `sha_single_output (32): the SHA256 of the corresponding output in CTxOut format`. In this case Embit was including the serialization of the output itself, not its SHA256 digest.

With these two changes I'm able to spend non-SIGHASH_ALL Taproot transactions made from PSBTs signed with Embit.


I'd like help adding the unit test that reproduces the issue, as for now I'm not able to understand test_taproot.py. I was able to check that the test suite is currently not covering these execution branches, though:

![Screenshot_2024-11-08_11-22-37](https://github.com/user-attachments/assets/c44e748f-5b58-4064-a023-bddd7312ad32)

