### PR TITLE
Reproducible Signed PSBTs

### DIFF
--- a/src/embit/psbt.py
+++ b/src/embit/psbt.py
@@ -977,22 +977,25 @@ class PSBT(EmbitBase):
                     continue
 
             # get all possible derivations with matching fingerprint
-            bip32_derivations = set()
+            bip32_derivations = OrderedDict()  # OrderedDict to keep order
             if fingerprint:
                 # if taproot derivations are present add them
                 for pub in inp.taproot_bip32_derivations:
                     (_leafs, derivation) = inp.taproot_bip32_derivations[pub]
                     if derivation.fingerprint == fingerprint:
-                        bip32_derivations.add((pub, derivation))
+                        # Add only if not already present
+                        if (pub, derivation) not in bip32_derivations:
+                            bip32_derivations[(pub, derivation)] = True
 
                 # segwit and legacy derivations
                 for pub in inp.bip32_derivations:
                     derivation = inp.bip32_derivations[pub]
                     if derivation.fingerprint == fingerprint:
-                        bip32_derivations.add((pub, derivation))
+                        if (pub, derivation) not in bip32_derivations:
+                            bip32_derivations[(pub, derivation)] = True
 
             # get derived keys for signing
-            derived_keypairs = set()  # (prv, pub)
+            derived_keypairs = OrderedDict()  # (prv, pub)
             for pub, derivation in bip32_derivations:
                 der = derivation.derivation
                 # descriptor key has origin derivation that we take into account
@@ -1008,7 +1011,9 @@ class PSBT(EmbitBase):
 
                 if hdkey.xonly() != pub.xonly():
                     raise PSBTError("Derivation path doesn't look right")
-                derived_keypairs.add((hdkey.key, pub))
+                # Insert into derived_keypairs if not present
+                if (hdkey.key, pub) not in derived_keypairs:
+                    derived_keypairs[(hdkey.key, pub)] = True
 
             # sign with taproot key
             if inp.is_taproot:


### PR DESCRIPTION
While developing tests for Embit's taproot miniscript capabilities in Krux, I noticed that final signed tap tree PSBTs could vary in content randomly, particularly when the same key was present in more than one leaf script. Investigating this with @jdlcdl, we found that the order of `taproot_script_path_sigs` could change unpredictably when running Embit on standard python.

Although these PSBTs would load and parse normally—both in coordinators and via bitcoin-cli—we wanted reproducible signed PSBTs for consistent tests and standardization across platforms.

Further investigation revealed that two variables within the `sign_with` function in psbt.py—`bip32_derivations` and `derived_keypairs`—were of type `set`, which does not preserve order. This led to random ordering in the final PSBT data whenever these `set` variables were read and written.

By replacing these `set` variables with `OrderedDict`, we ensured a stable ordering. This change should resolve the variability and achieves reproducible signed PSBTs across both MicroPython devices and standard PCs.