### PR TITLE
Add PSBT_IN_TAP_KEY_SIG field to PSBTs

### DIFF
--- a/src/embit/psbt.py
+++ b/src/embit/psbt.py
@@ -188,6 +188,7 @@ class InputScope(PSBTScope):
         self.taproot_bip32_derivations.update(other.taproot_bip32_derivations)
         self.taproot_internal_key = other.taproot_internal_key
         self.taproot_merkle_root = other.taproot_merkle_root or self.taproot_merkle_root
+        self.taproot_key_sig = other.taproot_key_sig or self.taproot_key_sig
         self.taproot_sigs.update(other.taproot_sigs)
         self.taproot_scripts.update(other.taproot_scripts)
         self.final_scriptsig = other.final_scriptsig or self.final_scriptsig
@@ -436,8 +437,10 @@ class InputScope(PSBTScope):
                 r += ser_string(stream, self.sequence.to_bytes(4, "little"))
 
         # PSBT_IN_TAP_KEY_SIG
-        r += ser_string(stream, b"\x13" + self.taproot_key_sig.serialize())
-
+        if self.taproot_key_sig is not None:
+            r += ser_string(stream, b"\x13")
+            r += ser_string(stream, self.taproot_key_sig)
+        
         # PSBT_IN_TAP_SCRIPT_SIG
         for pub, leaf in self.taproot_sigs:
             r += ser_string(stream, b"\x14" + pub.xonly() + leaf)
@@ -885,11 +888,11 @@ class PSBT(EmbitBase):
                 sighash=sighash,
             )
             sig = pk.schnorr_sign(h)
-            wit = sig.serialize()
+            sigdata = sig.serialize()
             if sighash != SIGHASH.DEFAULT:
-                wit += bytes([sighash])
-            inp.taproot_key_sig = sig
-            inp.final_scriptwitness = Witness([wit])
+                sigdata += bytes([sighash])
+            inp.taproot_key_sig = sigdata
+            inp.final_scriptwitness = Witness([sigdata])
             # no need to sign anything else
             return 1
         counter = 0

--- a/src/embit/psbt.py
+++ b/src/embit/psbt.py
@@ -142,6 +142,7 @@ class InputScope(PSBTScope):
         self.taproot_bip32_derivations = OrderedDict()
         self.taproot_internal_key = None
         self.taproot_merkle_root = None
+        self.taproot_key_sig = None
         self.taproot_sigs = OrderedDict()
         self.taproot_scripts = OrderedDict()
 
@@ -433,6 +434,9 @@ class InputScope(PSBTScope):
             if self.sequence is not None:
                 r += ser_string(stream, b"\x10")
                 r += ser_string(stream, self.sequence.to_bytes(4, "little"))
+
+        # PSBT_IN_TAP_KEY_SIG
+        r += ser_string(stream, b"\x13" + self.taproot_key_sig.serialize())
 
         # PSBT_IN_TAP_SCRIPT_SIG
         for pub, leaf in self.taproot_sigs:
@@ -884,7 +888,7 @@ class PSBT(EmbitBase):
             wit = sig.serialize()
             if sighash != SIGHASH.DEFAULT:
                 wit += bytes([sighash])
-            # TODO: maybe better to put into internal key sig field
+            inp.taproot_key_sig = sig
             inp.final_scriptwitness = Witness([wit])
             # no need to sign anything else
             return 1

--- a/src/embit/psbt.py
+++ b/src/embit/psbt.py
@@ -352,7 +352,15 @@ class InputScope(PSBTScope):
         elif k == b"\x10":
             self.sequence = int.from_bytes(v, "little")
 
-        # TODO: 0x13 - tap key signature
+        # PSBT_IN_TAP_KEY_SIG
+        elif k[0] == 0x13:
+            # read the taproot key sig
+            if len(k) != 1:
+                raise PSBTError("Invalid taproot key signature key")
+            if self.taproot_key_sig is not None:
+                raise PSBTError("Duplicated taproot key signature")
+            self.taproot_key_sig = v
+
         # PSBT_IN_TAP_SCRIPT_SIG
         elif k[0] == 0x14:
             if len(k) != 65:


### PR DESCRIPTION
Following guidance from @pythcoiner , we have implemented support for the PSBT_IN_TAP_KEY_SIG field. This addition addresses previously anticipated requirements, as indicated in the related comments, ensuring compatibility with internal key-signed Taproot PSBTs.