### PR TITLE
Miniscript - t Wrapper Verifies if Fragment Type is V

### DIFF
--- a/src/embit/descriptor/miniscript.py
+++ b/src/embit/descriptor/miniscript.py
@@ -870,6 +870,11 @@ class T(Wrapper):
 
     def __len__(self):
         return len(self.arg) + 1
+    
+    def verify(self):
+        super().verify()
+        if self.arg.type != "V":
+            raise MiniscriptError("t: X must be of type V")
 
     @property
     def properties(self):

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -199,6 +199,14 @@ class DescriptorTest(TestCase):
         for desc in generalistic_descs:
             Descriptor.from_string(desc)
 
+    def test_invalid_miniscript(self):
+        """Ensure an error is raised when parsing invalid miniscript"""
+        invalid_descs = [
+            "wsh(ttvtvtvtvtvtvtv:after(230775))",
+        ]
+        for desc in invalid_descs:
+            self.assertRaises(MiniscriptError, Descriptor.from_string, desc)
+    
     def test_len(self):
         """Checks that len(miniscript) returns correct length"""
         for op in OPERATORS:


### PR DESCRIPTION
This PR addresses issue #70 by adding a verification step to ensure that a Miniscript fragment wrapped by `t` is of type `V`. This addition resolves an inconsistency observed in this [very specific case](https://github.com/brunoerg/bitcoinfuzz/issues/113), between Embit  vs Bitcoin Core and Rust Miniscript implementations.

Note: While the new code aims to standardize behavior, further input from experienced miniscripters is welcome to confirm its effectiveness and to ensure that no additional inconsistencies are introduced.

Special thanks to @brunoerg and @erickcestari for the implementation work, @qlrd for encouraging the inclusion of Embit in the fuzz setup that caught the issue, @darosior for identifying the inconsistency and pointing a fix, and @jdlcdl for the in-depth review.