### PR TITLE
Replace Assertions with Conditional Error Raising

### DIFF
--- a/src/embit/bip85.py
+++ b/src/embit/bip85.py
@@ -17,7 +17,8 @@ def derive_entropy(root, app_index, path):
     """
     Derive app-specific bip85 entropy using path m/83696968'/app_index'/...path'
     """
-    assert max(path) < HARDENED_INDEX
+    if max(path) >= HARDENED_INDEX:
+        raise ValueError("Path elements must be less than 2^31")
     derivation = [HARDENED_INDEX + 83696968, HARDENED_INDEX + app_index] + [
         p + HARDENED_INDEX for p in path
     ]
@@ -27,7 +28,8 @@ def derive_entropy(root, app_index, path):
 
 def derive_mnemonic(root, num_words=12, index=0, language=LANGUAGES.ENGLISH):
     """Derive a new mnemonic with num_words using language (code, wordlist)"""
-    assert num_words in [12, 18, 24]
+    if num_words not in [12, 18, 24]:
+        raise ValueError("Number of words must be 12, 18 or 24")
     langcode, wordlist = language
     path = [langcode, num_words, index]
     entropy = derive_entropy(root, 39, path)
@@ -49,7 +51,9 @@ def derive_xprv(root, index=0):
 
 def derive_hex(root, num_bytes=32, index=0):
     """Derive raw entropy from 16 to 64 bytes long"""
-    assert num_bytes <= 64
-    assert num_bytes >= 16
+    if num_bytes > 64:
+        raise ValueError("Number of bytes must be less than 64")
+    if num_bytes < 16:
+        raise ValueError("Number of bytes must be at least 16")
     entropy = derive_entropy(root, 128169, [num_bytes, index])
     return entropy[:num_bytes]

--- a/src/embit/bip85.py
+++ b/src/embit/bip85.py
@@ -52,7 +52,7 @@ def derive_xprv(root, index=0):
 def derive_hex(root, num_bytes=32, index=0):
     """Derive raw entropy from 16 to 64 bytes long"""
     if num_bytes > 64:
-        raise ValueError("Number of bytes must be less than 64")
+        raise ValueError("Number of bytes must not exceed 64")
     if num_bytes < 16:
         raise ValueError("Number of bytes must be at least 16")
     entropy = derive_entropy(root, 128169, [num_bytes, index])

--- a/src/embit/descriptor/arguments.py
+++ b/src/embit/descriptor/arguments.py
@@ -15,7 +15,8 @@ class KeyOrigin:
     def from_string(cls, s: str):
         arr = s.split("/")
         mfp = unhexlify(arr[0])
-        assert len(mfp) == 4
+        if len(mfp) != 4:
+            raise ArgumentError("Invalid fingerprint length")
         arr[0] = "m"
         path = "/".join(arr)
         derivation = bip32.parse_path(path)
@@ -315,7 +316,8 @@ class Key(DescriptorBase):
         return self.key.xonly()
 
     def taproot_tweak(self, h=b""):
-        assert self.taproot
+        if not self.taproot:
+            raise ArgumentError("Key is not taproot")
         return self.key.taproot_tweak(h)
 
     def serialize(self):

--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -294,7 +294,7 @@ class Descriptor(DescriptorBase):
     @classmethod
     def read_from(cls, s):
         # starts with sh(wsh()), sh() or wsh()
-        start = s.read(7)
+        start = s.read(8)
         sh = False
         wsh = False
         wpkh = False
@@ -303,30 +303,30 @@ class Descriptor(DescriptorBase):
         taptree = TapTree()
         if start.startswith(b"tr("):
             taproot = True
-            s.seek(-4, 1)
+            s.seek(-5, 1)
         elif start.startswith(b"sh(wsh("):
             sh = True
             wsh = True
+            s.seek(-1, 1)
         elif start.startswith(b"wsh("):
             sh = False
             wsh = True
-            s.seek(-3, 1)
-        elif start.startswith(b"sh(wpkh"):
+            s.seek(-4, 1)
+        elif start.startswith(b"sh(wpkh("):
             is_miniscript = False
             sh = True
             wpkh = True
-            assert s.read(1) == b"("
         elif start.startswith(b"wpkh("):
             is_miniscript = False
             wpkh = True
-            s.seek(-2, 1)
+            s.seek(-3, 1)
         elif start.startswith(b"pkh("):
             is_miniscript = False
-            s.seek(-3, 1)
+            s.seek(-4, 1)
         elif start.startswith(b"sh("):
             sh = True
             wsh = False
-            s.seek(-4, 1)
+            s.seek(-5, 1)
         else:
             raise ValueError("Invalid descriptor (starts with '%s')" % start.decode())
         # taproot always has a key, and may have taptree miniscript

--- a/src/embit/ec.py
+++ b/src/embit/ec.py
@@ -26,7 +26,8 @@ class Signature(EmbitBase):
 
 class SchnorrSig(EmbitBase):
     def __init__(self, sig):
-        assert len(sig) == 64
+        if len(sig) != 64:
+            raise ECError("Invalid schnorr signature")
         self._sig = sig
 
     def write_to(self, stream) -> int:
@@ -93,7 +94,8 @@ class PublicKey(EmbitKey):
 
     @classmethod
     def from_xonly(cls, data: bytes):
-        assert len(data) == 32
+        if len(data) != 32:
+            raise ECError("Invalid xonly pubkey")
         return cls.parse(b"\x02" + data)
 
     def schnorr_verify(self, sig, msg_hash) -> bool:

--- a/src/embit/liquid/psetview.py
+++ b/src/embit/liquid/psetview.py
@@ -5,7 +5,8 @@ import hashlib
 
 def skip_commitment(stream):
     c = stream.read(1)
-    assert len(c) == 1
+    if len(c) != 1:
+        raise PSBTError("Unexpected end of stream")
     if c == b"\x00":  # None
         return 1
     if c == b"\x01":  # unconfidential

--- a/src/embit/misc.py
+++ b/src/embit/misc.py
@@ -35,7 +35,8 @@ def secure_randint(vmin: int, vmax: int) -> int:
     """
     import math
 
-    assert vmax > vmin
+    if vmax <= vmin:
+        raise ValueError("vmax must be greater than vmin")
     delta = vmax - vmin
     nbits = math.ceil(math.log2(delta + 1))
     randn = getrandbits(nbits)

--- a/src/embit/psbtview.py
+++ b/src/embit/psbtview.py
@@ -239,8 +239,10 @@ class PSBTView:
                     num_outputs = compact.from_bytes(value)
             elif key == b"\x00":
                 # we found global transaction
-                assert version != 2
-                assert (num_inputs is None) and (num_outputs is None)
+                if version == 2:
+                    raise PSBTError("Global transaction with version 2 PSBT")
+                if (num_inputs is not None) or (num_outputs is not None):
+                    raise PSBTError("Invalid global transaction")
                 tx_len = compact.read_from(stream)
                 cur += len(compact.to_bytes(tx_len))
                 tx_offset = cur

--- a/src/embit/util/ctypes_secp256k1.py
+++ b/src/embit/util/ctypes_secp256k1.py
@@ -761,16 +761,20 @@ def xonly_pubkey_from_pubkey(pubkey, context=_secp.ctx):
 
 @locked
 def schnorrsig_verify(sig, msg, pubkey, context=_secp.ctx):
-    assert len(sig) == 64
-    assert len(msg) == 32
-    assert len(pubkey) == 64
+    if len(sig) != 64:
+        raise ValueError("Signature should be 64 bytes long")
+    if len(msg) != 32:
+        raise ValueError("Message should be 32 bytes long")
+    if len(pubkey) != 64:
+        raise ValueError("Public key should be 64 bytes long")
     res = _secp.secp256k1_schnorrsig_verify(context, sig, msg, pubkey)
     return bool(res)
 
 
 @locked
 def keypair_create(secret, context=_secp.ctx):
-    assert len(secret) == 32
+    if len(secret) != 32:
+        raise ValueError("Secret key should be 32 bytes long")
     keypair = bytes(96)
     r = _secp.secp256k1_keypair_create(context, keypair, secret)
     if r == 0:
@@ -782,11 +786,13 @@ def keypair_create(secret, context=_secp.ctx):
 def schnorrsig_sign(
     msg, keypair, nonce_function=None, extra_data=None, context=_secp.ctx
 ):
-    assert len(msg) == 32
+    if len(msg) != 32:
+        raise ValueError("Message should be 32 bytes long")
     if len(keypair) == 32:
         keypair = keypair_create(keypair, context=context)
     with _lock:
-        assert len(keypair) == 96
+        if len(keypair) != 96:
+            raise ValueError("Keypair should be 96 bytes long")
         sig = bytes(64)
         r = _secp.secp256k1_schnorrsig_sign(
             context, sig, msg, keypair, nonce_function, extra_data
@@ -916,7 +922,8 @@ def pedersen_blind_generator_blind_sum(
     if res == 0:
         raise ValueError("Failed to get the last blinding factor.")
     res = (c_char * 32).from_address(address).raw
-    assert len(res) == 32
+    if len(res) != 32:
+        raise ValueError("Blinding factor should be 32 bytes long")
     return res
 
 

--- a/src/embit/util/py_ripemd160.py
+++ b/src/embit/util/py_ripemd160.py
@@ -359,7 +359,7 @@ def fi(x, y, z, i):
     elif i == 4:
         return x ^ (y | ~z)
     else:
-        assert False
+        raise ValueError("Invalid function index")
 
 
 def rol(x, i):

--- a/src/embit/util/py_secp256k1.py
+++ b/src/embit/util/py_secp256k1.py
@@ -283,9 +283,12 @@ def xonly_pubkey_from_pubkey(pubkey, context=None):
 
 
 def schnorrsig_verify(sig, msg, pubkey, context=None):
-    assert len(sig) == 64
-    assert len(msg) == 32
-    assert len(pubkey) == 64
+    if len(sig) != 64:
+        raise ValueError("Signature should be 64 bytes long")
+    if len(msg) != 32:
+        raise ValueError("Message should be 32 bytes long")
+    if len(pubkey) != 64:
+        raise ValueError("Public key should be 64 bytes long")
     sec = ec_pubkey_serialize(pubkey)
     return _key.verify_schnorr(sec[1:33], sig, msg)
 
@@ -298,10 +301,12 @@ def keypair_create(secret, context=None):
 
 
 def schnorrsig_sign(msg, keypair, nonce_function=None, extra_data=None, context=None):
-    assert len(msg) == 32
+    if len(msg) != 32:
+        raise ValueError("Message should be 32 bytes long")
     if len(keypair) == 32:
         keypair = keypair_create(keypair, context=context)
-    assert len(keypair) == 96
+    if len(keypair) != 96:
+        raise ValueError("Keypair should be 96 bytes long")
     return _key.sign_schnorr(keypair[:32], msg, extra_data)
 
 

--- a/tests/tests/test_bip85.py
+++ b/tests/tests/test_bip85.py
@@ -104,7 +104,7 @@ class Bip85Test(TestCase):
         for num_bytes in [65, 100, 1000, 10000]:
             with self.assertRaises(ValueError) as exc:
                 bip85.derive_hex(ROOT, num_bytes, 1)
-            self.assertEqual(str(exc.exception), "Number of bytes must be less than 64")
+            self.assertEqual(str(exc.exception), "Number of bytes must not exceed 64")
 
     def test_hex_fail_num_bytes_le_16(self):
         for num_bytes in [15, 14, 10, 0]:

--- a/tests/tests/test_bip85.py
+++ b/tests/tests/test_bip85.py
@@ -48,11 +48,43 @@ VECTORS_HEX = [
 
 
 class Bip85Test(TestCase):
+
+    def test_derive_entropy(self):
+        for app_index, path, expected in [
+            (39, [0, 12, 0], unhexlify("6250b68daf746d12a24d58b4787a714bf1b58d69e4c2a466276fb16fe93dc52b6fac6b756894072241447cad56f6405ee326dbb473d2f5e943543590082927c0")),
+            (2, [0], unhexlify("7040bb53104f27367f317558e78a994ada7296c6fde36a364e5baf206e502bb1f988080b7dd814e7ae7d6d83edbb6689886a560e165f4a740877cdf3beecacf8")),
+            (32, [0], unhexlify("52405cd0dd21c5be78314a7c1a3c65ffd8d896536cc7dee3157db5824f0c92e2ead0b33988a616cf6a497f1c169d9e92562604e38305ccd3fc96f2252c177682")),
+        ]:
+            result = bip85.derive_entropy(ROOT, app_index, path)
+            self.assertEqual(result, expected)
+
+    def test_derive_entropy_fail_path_ge_hardened_index(self):
+        with self.assertRaises(ValueError) as exc:
+            bip85.derive_entropy(ROOT, 39, [bip32.HARDENED_INDEX + 1])
+        self.assertEqual(str(exc.exception), "Path elements must be less than 2^31")
+
     def test_bip39(self):
         for num_words, index, lang, expected in VECTORS_BIP39:
             self.assertEqual(
                 bip85.derive_mnemonic(ROOT, num_words, index, language=lang), expected
             )
+
+    def test_bip39_fail_num_words(self):
+        cases = [
+            (11, 0, bip85.LANGUAGES.ENGLISH),
+            (13, 0, bip85.LANGUAGES.ENGLISH),
+            (15, 0, bip85.LANGUAGES.ENGLISH),
+            (17, 0, bip85.LANGUAGES.ENGLISH),
+            (19, 0, bip85.LANGUAGES.ENGLISH),
+            (21, 0, bip85.LANGUAGES.ENGLISH),
+            (23, 0, bip85.LANGUAGES.ENGLISH),
+            (25, 0, bip85.LANGUAGES.ENGLISH),
+        ]
+
+        for num_words, index, lang in cases:
+            with self.assertRaises(ValueError) as exc:
+                bip85.derive_mnemonic(ROOT, num_words, index, language=lang)
+            self.assertEqual(str(exc.exception), "Number of words must be 12, 18 or 24")
 
     def test_wif(self):
         for idx, expected in VECTORS_WIF:
@@ -67,3 +99,15 @@ class Bip85Test(TestCase):
             self.assertEqual(
                 bip85.derive_hex(ROOT, num_bytes, idx), unhexlify(expected)
             )
+
+    def test_hex_fail_num_bytes_ge_64(self):
+        for num_bytes in [65, 100, 1000, 10000]:
+            with self.assertRaises(ValueError) as exc:
+                bip85.derive_hex(ROOT, num_bytes, 1)
+            self.assertEqual(str(exc.exception), "Number of bytes must be less than 64")
+
+    def test_hex_fail_num_bytes_le_16(self):
+        for num_bytes in [15, 14, 10, 0]:
+            with self.assertRaises(ValueError) as exc:
+                bip85.derive_hex(ROOT, num_bytes, 2)
+            self.assertEqual(str(exc.exception), "Number of bytes must be at least 16")


### PR DESCRIPTION
Some consider `assert` suitable only for debugging because, as when a Python script is executed with the `-O` (optimize) flag, all `assert` statements are stripped from the code at runtime.

This is particularly relevant in Android environments, where Buildozer, by default, runs with the `-O` flag enabled. As a result, important validation checks implemented with assert would be skipped entirely.

We have already been using these changes in the Krux Android app for some time, and we believe adopting this approach more broadly would be beneficial.