### PR TITLE
 BIP-353 DNSSEC proof support to PSBT

### DIFF
--- a/src/embit/psbt.py
+++ b/src/embit/psbt.py
@@ -504,6 +504,8 @@ class OutputScope(PSBTScope):
         self.bip32_derivations = OrderedDict()
         self.taproot_bip32_derivations = OrderedDict()
         self.taproot_internal_key = None
+        self.dnssec_name = None
+        self.dnssec_proof = None
         self.parse_unknowns()
 
     def clear_metadata(self, compress=CompressMode.CLEAR_ALL):
@@ -516,6 +518,8 @@ class OutputScope(PSBTScope):
         self.bip32_derivations = OrderedDict()
         self.taproot_bip32_derivations = OrderedDict()
         self.taproot_internal_key = None
+        self.dnssec_name = None
+        self.dnssec_proof = None
 
     def update(self, other):
         self.value = other.value if other.value is not None else self.value
@@ -526,6 +530,8 @@ class OutputScope(PSBTScope):
         self.bip32_derivations.update(other.bip32_derivations)
         self.taproot_bip32_derivations.update(other.taproot_bip32_derivations)
         self.taproot_internal_key = other.taproot_internal_key
+        self.dnssec_name = other.dnssec_name or self.dnssec_name
+        self.dnssec_proof = other.dnssec_proof or self.dnssec_proof
 
     @property
     def vout(self):
@@ -583,6 +589,18 @@ class OutputScope(PSBTScope):
                 der = DerivationPath.read_from(b)
                 self.taproot_bip32_derivations[pub] = (leaf_hashes, der)
 
+        # PSBT_OUT_DNSSEC_PROOF (0x35)
+        elif k == b"\x35":
+            if self.dnssec_proof is not None:
+                raise PSBTError("Duplicated DNSSEC proof")
+            if len(v) < 1:
+                raise PSBTError("Invalid DNSSEC proof (missing length)")
+            name_len = v[0]
+            if len(v) < 1 + name_len:
+                raise PSBTError("Invalid DNSSEC proof (truncated name)")
+            self.dnssec_name = v[1 : 1 + name_len]
+            self.dnssec_proof = v[1 + name_len :]
+
         else:
             if k in self.unknown:
                 raise PSBTError("Duplicated key")
@@ -623,6 +641,18 @@ class OutputScope(PSBTScope):
                 + b"".join(leaf_hashes)
                 + derivation.serialize(),
             )
+
+        # PSBT_OUT_DNSSEC_PROOF (BIP-353)
+        if self.dnssec_proof is not None and self.dnssec_name is not None:
+            if len(self.dnssec_name) > 255:
+                raise PSBTError("DNSSEC name too long")
+            value = (
+                len(self.dnssec_name).to_bytes(1, "big")
+                + self.dnssec_name
+                + self.dnssec_proof
+            )
+            r += ser_string(stream, b"\x35")
+            r += ser_string(stream, value)
 
         # unknown
         for key in self.unknown:


### PR DESCRIPTION
implemented the new PSBT_OUT_DNSSEC_PROOF = 0x35 output-scope key introduced by [BIP-353](https://github.com/bitcoin/bips/blob/master/bip-0353.mediawiki) so that PSBTs can carry DNSSEC proof for a human-readable payment identifier (user@domain).