### PR TITLE
Update pyproject.toml to include poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,16 @@
+[tool.poetry]
+name = "embit"
+version = "0.8.0"
+description="A minimal bitcoin library for MicroPython and Python3 with a focus on embedded systems."
+license="MIT"
+authors= ["Stepan Snigirev <snigirev.stepan@gmail.com>"]
+
+[tool.poetry.urls]
+repository = "https://github.com/diybitcoinhardware/embit"
+
+[tool.poetry.dependencies]
+python = "^3.0"
+
 [build-system]
 requires = ["setuptools>=42.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR fixes Poetry-related issues: Krux cannot use **embit** in `[tool.poetry.dependencies]` with `develop=true`. Otherwise, `poetry install` or `poetry lock` fails with `Unable to create package with no name`.
