### PR TITLE
mnemonics with double spaces, \n as separators, trailing and leading spaces should be invalid

### DIFF
--- a/src/embit/bip39.py
+++ b/src/embit/bip39.py
@@ -10,7 +10,7 @@ PBKDF2_ROUNDS = const(2048)
 def mnemonic_to_bytes(mnemonic: str, ignore_checksum: bool = False, wordlist=WORDLIST):
     # this function is copied from Jimmy Song's HDPrivateKey.from_mnemonic() method
 
-    words = mnemonic.strip().split()
+    words = mnemonic.split(" ")
     if len(words) % 3 != 0 or len(words) < 12:
         raise ValueError("Invalid recovery phrase")
 
@@ -68,7 +68,7 @@ def mnemonic_is_valid(mnemonic: str, wordlist=WORDLIST):
     try:
         mnemonic_to_bytes(mnemonic, wordlist=wordlist)
         return True
-    except Exception as e:
+    except Exception:
         return False
 
 

--- a/tests/tests/test_bip39.py
+++ b/tests/tests/test_bip39.py
@@ -190,6 +190,21 @@ class Bip39Test(TestCase):
         seed = "0000000000000000000000000000000042"
         self.assertRaises(ValueError, lambda x: mnemonic_from_bytes(unhexlify(x)), seed)
 
+    def test_spaces(self):
+        """Test that mnemonic with leading / trailing / double spaces are invalid."""
+        # valid mnemonic
+        mnemonic = "abandon " * 11 + "about"
+        self.assertTrue(mnemonic_is_valid(mnemonic))
+        # leading / trailing space
+        self.assertFalse(mnemonic_is_valid(" " + mnemonic))
+        self.assertFalse(mnemonic_is_valid(mnemonic + " "))
+        # double space
+        mnemonic = "abandon " * 11 + " about"
+        self.assertFalse(mnemonic_is_valid(mnemonic))
+        # new line instead of space
+        mnemonic = "abandon\n" * 11 + "about"
+        self.assertFalse(mnemonic_is_valid(mnemonic))
+
     def test_find_candidates_happy(self):
         prefix = "a"
         exp_candidates = [


### PR DESCRIPTION
Previously mnemonics with leading / trailing / double spaces or with `\n` or `\r` as word separator were treated as valid by `mnemonic_is_valid` and underlying `mnemonic_to_entropy` functions. This could cause a problem because this mnemonic was passed to pbkdf2 as is, without any normalization. So mnemonics like this would give an invalid seed.

I was considering either normalizing mnemonics before sending to pbkdf2 and be more forgiving to user input, or be strict and enforce single spaces between words. In this situation I think it's better to be more strict, and wallet designers can relax this requirements by doing something like `" ".join(mnemonic.split())` if they want, or using `mnemonic.strip()` especially when reading from text file. Just keep in mind that doing something like that will create additional copies of the mnemonic in RAM.