### PR TITLE
Add testnet4 network support (Bitcoin Core 28.0+)

### DIFF
--- a/src/embit/liquid/networks.py
+++ b/src/embit/liquid/networks.py
@@ -4,10 +4,21 @@ const = lambda x: x
 
 
 def get_network(name):
+    """
+    Get network configuration by name.
+    
+    Checks liquid networks first (liquidv1, elementsregtest, liquidtestnet),
+    then falls back to Bitcoin networks (main, test, regtest, signet, testnet4).
+    Only defaults to elementsregtest for truly unknown networks.
+    """
     if name in NETWORKS:
         return NETWORKS[name]
-    else:
-        return NETWORKS["elementsregtest"]
+    # Check if it's a known Bitcoin network (added after NETWORKS is defined)
+    # This handles testnet4 and other Bitcoin networks correctly
+    if name in networks.NETWORKS:
+        return networks.NETWORKS[name]
+    # Only fall back to elementsregtest for unknown networks
+    return NETWORKS["elementsregtest"]
 
 
 NETWORKS = {

--- a/src/embit/networks.py
+++ b/src/embit/networks.py
@@ -73,4 +73,24 @@ NETWORKS = {
         "Zpub": b"\x02\x57\x54\x83",
         "bip32": const(1),
     },
+    # testnet4 uses the same address formats as testnet3
+    # Added for Bitcoin Core 28.0+ compatibility (getblockchaininfo returns "testnet4")
+    "testnet4": {
+        "name": "Testnet4",
+        "wif": b"\xEF",
+        "p2pkh": b"\x6F",
+        "p2sh": b"\xC4",
+        "bech32": "tb",
+        "xprv": b"\x04\x35\x83\x94",
+        "xpub": b"\x04\x35\x87\xcf",
+        "yprv": b"\x04\x4a\x4e\x28",
+        "zprv": b"\x04\x5f\x18\xbc",
+        "Yprv": b"\x02\x42\x85\xb5",
+        "Zprv": b"\x02\x57\x50\x48",
+        "ypub": b"\x04\x4a\x52\x62",
+        "zpub": b"\x04\x5f\x1c\xf6",
+        "Ypub": b"\x02\x42\x89\xef",
+        "Zpub": b"\x02\x57\x54\x83",
+        "bip32": const(1),
+    },
 }

--- a/tests/tests/test_networks.py
+++ b/tests/tests/test_networks.py
@@ -1,0 +1,77 @@
+from unittest import TestCase
+from embit import networks
+from embit.liquid import networks as liquid_networks
+
+
+class NetworksTest(TestCase):
+    """Tests for network configuration."""
+
+    def test_testnet4_exists(self):
+        """testnet4 should be a known network."""
+        self.assertIn("testnet4", networks.NETWORKS)
+
+    def test_testnet4_parameters(self):
+        """testnet4 should use the same address formats as testnet3."""
+        testnet4 = networks.NETWORKS["testnet4"]
+        testnet = networks.NETWORKS["test"]
+        
+        # testnet4 uses tb1 addresses like testnet3
+        self.assertEqual(testnet4["bech32"], "tb")
+        self.assertEqual(testnet4["bech32"], testnet["bech32"])
+        
+        # Same BIP32 prefixes (tpub/tprv)
+        self.assertEqual(testnet4["xpub"], testnet["xpub"])
+        self.assertEqual(testnet4["xprv"], testnet["xprv"])
+        
+        # Same WIF prefix
+        self.assertEqual(testnet4["wif"], testnet["wif"])
+        
+        # Same P2PKH/P2SH prefixes
+        self.assertEqual(testnet4["p2pkh"], testnet["p2pkh"])
+        self.assertEqual(testnet4["p2sh"], testnet["p2sh"])
+        
+        # Same coin type for BIP32 derivation
+        self.assertEqual(testnet4["bip32"], testnet["bip32"])
+
+    def test_testnet4_name(self):
+        """testnet4 should have its own name."""
+        testnet4 = networks.NETWORKS["testnet4"]
+        self.assertEqual(testnet4["name"], "Testnet4")
+
+    def test_liquid_get_network_testnet4(self):
+        """liquid.networks.get_network('testnet4') should return Bitcoin testnet4, not elementsregtest."""
+        net = liquid_networks.get_network("testnet4")
+        
+        # Should NOT fall back to elementsregtest
+        self.assertNotEqual(net["bech32"], "ert")
+        
+        # Should return testnet4 with tb prefix
+        self.assertEqual(net["bech32"], "tb")
+        self.assertEqual(net["name"], "Testnet4")
+
+    def test_liquid_get_network_known_networks(self):
+        """liquid.networks.get_network should find all Bitcoin networks."""
+        for name in ["main", "test", "regtest", "signet", "testnet4"]:
+            net = liquid_networks.get_network(name)
+            self.assertEqual(net["name"], networks.NETWORKS[name]["name"])
+
+    def test_liquid_get_network_liquid_networks(self):
+        """liquid.networks.get_network should find liquid-specific networks."""
+        # These should return liquid networks, not fall back
+        self.assertEqual(liquid_networks.get_network("liquidv1")["bech32"], "ex")
+        self.assertEqual(liquid_networks.get_network("elementsregtest")["bech32"], "ert")
+        self.assertEqual(liquid_networks.get_network("liquidtestnet")["bech32"], "tex")
+
+    def test_liquid_get_network_unknown_fallback(self):
+        """liquid.networks.get_network should fall back to elementsregtest for unknown networks."""
+        net = liquid_networks.get_network("unknown_network_xyz")
+        self.assertEqual(net["bech32"], "ert")
+        self.assertEqual(net["name"], "Liquid Regtest")
+
+    def test_all_networks_have_required_keys(self):
+        """All networks should have the required configuration keys."""
+        required_keys = ["name", "wif", "p2pkh", "p2sh", "bech32", "xprv", "xpub", "bip32"]
+        
+        for name, net in networks.NETWORKS.items():
+            for key in required_keys:
+                self.assertIn(key, net, f"Network '{name}' missing key '{key}'")


### PR DESCRIPTION
## Summary

Bitcoin Core 28.0+ introduces testnet4 with chain name `testnet4` (returned by `getblockchaininfo`). This PR adds proper support for testnet4.

## Changes

### 1. Add testnet4 to `networks.py`
Added testnet4 network configuration with the same address parameters as testnet3:
- bech32 prefix: `tb` 
- BIP32 prefixes: tpub/tprv
- Same WIF, P2PKH, P2SH prefixes as testnet

### 2. Fix `liquid/networks.py` get_network fallback behavior
Previously, `get_network('testnet4')` would silently fall back to `elementsregtest` (bech32 prefix `ert`), causing applications to generate Liquid addresses instead of testnet addresses.

Now the function checks Bitcoin networks before falling back:
1. Check liquid-specific networks (liquidv1, elementsregtest, liquidtestnet)
2. Check Bitcoin networks (main, test, regtest, signet, testnet4)  
3. Only fall back to elementsregtest for truly unknown networks

### 3. Add comprehensive tests
New `test_networks.py` with 8 tests covering:
- testnet4 existence and parameters
- Comparison with testnet3 parameters
- `get_network()` behavior for Bitcoin networks
- `get_network()` behavior for liquid networks
- Fallback behavior for unknown networks

## Testing

```bash
cd /tmp/embit && PYTHONPATH=src python3 -m unittest tests.tests.test_networks -v
```

All 8 new tests pass. Existing liquid tests also pass.

Fixes #108