### PR TITLE
chore: lint hygiene for examples folder 

### DIFF
--- a/examples/addresses.py
+++ b/examples/addresses.py
@@ -1,7 +1,7 @@
-from embit import script
-from embit import ec
+from binascii import hexlify, unhexlify
+
+from embit import ec, script
 from embit.networks import NETWORKS
-from binascii import unhexlify, hexlify
 
 
 def main():

--- a/examples/change.py
+++ b/examples/change.py
@@ -5,9 +5,11 @@ Multisig transaction verification example:
 - checks that change output is from the same wallet as well
 - prints out transaction information for the user
 """
-from embit import bip39, bip32, psbt, script, ec
+
 from binascii import a2b_base64, b2a_base64
 from io import BytesIO
+
+from embit import bip32, bip39, ec, psbt, script
 
 
 def parse_multisig(sc):

--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -3,13 +3,15 @@ This example shows how to fetch utxos from mempool.space
 and build PSBT transaction for signing.
 Requires `requests` module (`pip3 install requests`)
 """
+
 import requests
+
+from embit import bip32, finalizer, script
 from embit.descriptor import Descriptor
+from embit.ec import PublicKey
 from embit.networks import NETWORKS
 from embit.psbt import PSBT, DerivationPath
-from embit.ec import PublicKey
 from embit.transaction import Transaction, TransactionInput, TransactionOutput
-from embit import script, bip32, finalizer
 
 # link to the explorer API (esplora or mempool.space)
 # API = "https://mempool.space/testnet/api"
@@ -117,9 +119,11 @@ for branch in [0]:  # range(len(desc.num_branches)):
                     "witness_script": ws,
                     "redeem_script": rs,
                     "bip32_derivations": bip32_derivations,
-                    "witness_utxo": TransactionOutput(utxo["value"], script_pubkey)
-                    if d.is_segwit
-                    else None,
+                    "witness_utxo": (
+                        TransactionOutput(utxo["value"], script_pubkey)
+                        if d.is_segwit
+                        else None
+                    ),
                 }
                 for utxo in utxoarr
             ]

--- a/examples/hdkey.py
+++ b/examples/hdkey.py
@@ -1,8 +1,7 @@
-from embit import script
-from embit import bip32
-from embit import bip39
-from embit.networks import NETWORKS
 import random
+
+from embit import bip32, bip39, script
+from embit.networks import NETWORKS
 
 # example of key and address derivations from mnemonic
 # you can check that everything works right

--- a/examples/psbt.py
+++ b/examples/psbt.py
@@ -1,12 +1,8 @@
-from embit import script
-from embit import bip32
-from embit import bip39
-from embit.networks import NETWORKS
-from embit import psbt
-from binascii import unhexlify, hexlify
-
 # base64 encoding
-from binascii import a2b_base64, b2a_base64
+from binascii import a2b_base64, b2a_base64, hexlify
+
+from embit import bip32, bip39, psbt, script
+from embit.networks import NETWORKS
 
 # example of key and address derivations from mnemonic
 # you can check that everything works right

--- a/examples/transactions.py
+++ b/examples/transactions.py
@@ -1,9 +1,7 @@
-from embit import script
-from embit import ec
-from embit.networks import NETWORKS
-from binascii import unhexlify, hexlify
+from binascii import hexlify, unhexlify
+
+from embit import ec, script
 from embit.transaction import Transaction, TransactionInput, TransactionOutput
-from embit import compact
 
 
 def main():


### PR DESCRIPTION
This PR partially supersede #98 and introduces a set of small code-quality changes
(mostly lint and import sorting ones) on `examples/**/*.py`