### PR TITLE
Bump wheel from 0.45.1 to 0.47.0

### DIFF
--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -906,5 +906,6 @@ watchdog==6.0.0 ; python_version >= "3.10" \
     --hash=sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f \
     --hash=sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282
 
-wheel==0.45.1 ; python_version >= "3.10" \
-    --hash=sha256:708e7481cc80179af0e556bbf0cc00b8444c7321e2700b8d8580231d13017248
+wheel==0.47.0 ; python_version >= "3.10" \
+    --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced \
+    --hash=sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools==80.9.0",
-    "wheel==0.45.1",
+    "wheel==0.47.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Bumps the build-system `wheel` pin to `0.47.0` and refreshes hashed dev constraints.