### PR TITLE
docs: add pip instructions when using zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ mnemonic_from_bytes(bytes_data, wordlist=spanish_wordlist)
 Install in developer mode with dev dependencies:
 
 ```sh
+# sh, bash based environments
 pip install -e .[dev]
+
+# zsh based environments
+pip install -e ".[dev]"
 ```
 
 Install pre-commit hook:


### PR DESCRIPTION
`pip install -e .[dev]` works fine in `sh/bash` and (which is what `README.md` assume). In zsh, unquoted `[...]` could be interpreted as a glob pattern, so zsh tries to expand .[dev] as a filename match and errors before pip ever runs. This commit add an instruction for `zsh` with `pip install -e ".[dev]"` on `README.md`.