### PR TITLE
docs(secp256k1): document local build loading and submodule init

### DIFF
--- a/secp256k1/README.md
+++ b/secp256k1/README.md
@@ -13,6 +13,11 @@ git clone --recursive https://github.com/diybitcoinhardware/embit.git
 
 This will automatically pull in the `libsecp256k1-zkp` repo and checkout the correct commit within that repo.
 
+Alternatively, if you already have `embit` cloned, run:
+```sh
+git submodule update --recursive --init
+```
+
 
 ## Building the library
 This directory (`secp256k1/` in the `embit` root) already has a fully-configured Makefile to run the compilation for you.
@@ -21,6 +26,37 @@ On your target platform run:
 ```sh
 make
 ```
+
+This creates a platform-specific shared library under `secp256k1/build/`, for
+example:
+
+```sh
+secp256k1/build/libsecp256k1_linux_x86_64.so
+```
+
+## Loading the local build in Python
+
+`embit` looks for local libsecp256k1 artifacts in
+`secp256k1/secp256k1-zkp/.libs/` before falling back to system library paths.
+After running `make`, expose the helper Makefile output at that lookup path:
+
+```sh
+mkdir -p secp256k1-zkp/.libs
+ln -sf ../../build/libsecp256k1_$(uname -s | tr A-Z a-z)_$(uname -m).so \
+  secp256k1-zkp/.libs/libsecp256k1.so
+```
+
+Run those commands from the `secp256k1/` directory. On macOS, replace the
+`.so` suffix with `.dylib`.
+
+You can verify that Python loaded the native backend from the repository root:
+
+```sh
+PYTHONPATH=src python -c "from embit.ec import secp256k1; print(hasattr(secp256k1, 'ecdh'), hasattr(secp256k1, 'rangeproof_rewind'))"
+```
+
+Both values should print `True`. If they do, the optional ECDH and Liquid/ZKP
+tests can run instead of being skipped.
 
 Install the resulting library into a standard system library location so the dynamic loader can find it (for example `/usr/local/lib` on Unix-like systems), then refresh your linker environment as needed for your platform.
 


### PR DESCRIPTION
- Document git submodule update --recursive --init as a fallback when embit was cloned without --recursive.
- Show how to symlink the local make output into secp256k1-zkp/.libs/ so Python picks up the native backend, with a one-liner to verify ecdh/rangeproof_rewind are exposed.
#### Test plan
- Follow the README steps on Linux and confirm the verification command prints True True.
- Repeat on macOS with the .dylib suffix.