### PR TITLE
chore: lint hygiene on `tests/integration` folder

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -5,10 +5,11 @@ if sys.implementation.name == "micropython":
     print("This file should run with python3, not micropython!")
     sys.exit(1)
 
+import time
+import unittest
+
 from util.bitcoin import daemon as bitcoind
 from util.liquid import daemon as elementsd
-import unittest
-import time
 
 
 def main():

--- a/tests/integration/tests/test_psbt.py
+++ b/tests/integration/tests/test_psbt.py
@@ -1,9 +1,11 @@
-from unittest import TestCase, skip
-from util.bitcoin import daemon
 import random
+from unittest import TestCase, skip
+
+from util.bitcoin import daemon
+
+from embit.bip32 import HDKey
 from embit.descriptor import Descriptor
 from embit.descriptor.checksum import add_checksum
-from embit.bip32 import HDKey
 from embit.networks import NETWORKS
 from embit.psbt import PSBT
 

--- a/tests/integration/tests/test_pset.py
+++ b/tests/integration/tests/test_pset.py
@@ -1,18 +1,19 @@
-from unittest import TestCase, skip
-from util.liquid import daemon
+import os
 import random
 import time
-import os
+from unittest import TestCase, skip
 
-from embit.liquid.descriptor import LDescriptor as Descriptor
-from embit.descriptor.checksum import add_checksum
+from util.liquid import daemon
+
 from embit.bip32 import HDKey
+from embit.descriptor.checksum import add_checksum
+from embit.ec import PrivateKey
+from embit.liquid.addresses import addr_decode
+from embit.liquid.descriptor import LDescriptor as Descriptor
+from embit.liquid.finalizer import finalize_psbt
 from embit.liquid.networks import get_network
 from embit.liquid.pset import PSET as PSBT
 from embit.liquid.transaction import LSIGHASH
-from embit.liquid.finalizer import finalize_psbt
-from embit.liquid.addresses import addr_decode
-from embit.ec import PrivateKey
 
 wallet_prefix = "test" + random.randint(0, 0xFFFFFFFF).to_bytes(4, "big").hex()
 root = HDKey.from_string(

--- a/tests/integration/util/bitcoin.py
+++ b/tests/integration/util/bitcoin.py
@@ -1,8 +1,9 @@
-import subprocess
 import os
-import time
-import signal
 import shutil
+import signal
+import subprocess
+import time
+
 from .rpc import BitcoinRPC
 
 

--- a/tests/integration/util/liquid.py
+++ b/tests/integration/util/liquid.py
@@ -1,4 +1,5 @@
 import os
+
 from .bitcoin import Bitcoind
 
 

--- a/tests/integration/util/rpc.py
+++ b/tests/integration/util/rpc.py
@@ -1,7 +1,11 @@
+import errno
+import json
 import logging
-import requests, json, os
-import os, sys, errno
+import os
+import sys
 import time
+
+import requests
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR apply some formatting, lint and import sorting on `tests/integration` folder with ruff and isort (with black profile) tools.

Follow up of #118.