### PR TITLE
Document that Descriptor.derive() preserves key expression order

### DIFF
--- a/src/embit/descriptor/descriptor.py
+++ b/src/embit/descriptor/descriptor.py
@@ -160,6 +160,10 @@ class Descriptor(DescriptorBase):
         return s
 
     def derive(self, idx, branch_index=None):
+        """Derive the descriptor, filling in the wildcard index and branch.
+
+        Key order is preserved: ``derived.keys[i]`` matches ``self.keys[i]``.
+        """
         if self.miniscript:
             return type(self)(
                 self.miniscript.derive(idx, branch_index),

--- a/src/embit/descriptor/miniscript.py
+++ b/src/embit/descriptor/miniscript.py
@@ -25,6 +25,7 @@ class Miniscript(DescriptorBase):
         )
 
     def derive(self, idx, branch_index=None):
+        """Derive the miniscript. Key expressions stay in descriptor order."""
         args = [
             arg.derive(idx, branch_index) if hasattr(arg, "derive") else arg
             for arg in self.args

--- a/tests/tests/test_descriptor.py
+++ b/tests/tests/test_descriptor.py
@@ -382,6 +382,44 @@ class DescriptorTest(TestCase):
 
             assert n_branches == d.num_branches
 
+    def test_derive_preserves_key_order(self):
+        keys = [
+            "[73c5da0a/84h/1h/0h]xpub6Bm9M1SxZdzL3TxdNV8897FgtTLBgehR1wVNnMyJ5VLRK5n3tFqXxrCVnVQj4zooN4eFSkf6Sma84reWc5ZCXMxPbLXQs3BcaBdTd4YQa3B/<0;1>/*",
+            "[b8688df1/84h/1h/0h]xpub6CnR9ceMJcBFAg8y4vVgVzyXt9AMriyKTKXnJr11BfFBqfRqXkBnBxsNhA8jA8aArgXohYigjE7Nb38iAbqgvqvR1uuAjFRKbrdqgnmR3gK/<0;1>/*",
+            "[28645006/84h/1h/0h]xpub6CQsXJLdHPurvSJPjvbgsy1goTjuo5cQAQ6Yre5Sd2SxZ9wuSmhMttYQqqHQZAfA2j5HrSprnPWrgzgTkJyzzA4i7QhMfceNU8rASftZjjc/<0;1>/*",
+            "[f57f296d/84h/1h/0h]xpub6DQWqHZqv3PvzWhbDRUEcEhasLZxGsiF4r7GTcmCZcdTXFB3JTYKKt3U9qDnPdV7XNRP7mGtJf6FF8hxGykp2FKczcvfUxHhw4uLLh7PsB4/<0;1>/*",
+            "[dd1fad4d/84h/1h/0h]xpub6BnZob7d8SavYRAFaBXaNu5WftG6jKwSGiDWveKbbNkLisjhfcocV7H32MZKSk6YAsHii9743UzDKeuNfh8rqMTP9641LPKBSbotwfnEFgF/<0;1>/*",
+        ]
+        descriptors = [
+            ("wpkh", "wpkh(%s)" % keys[0]),
+            ("multi", "wsh(multi(2,%s,%s,%s,%s,%s))" % tuple(keys)),
+            ("sortedmulti", "wsh(sortedmulti(3,%s,%s,%s,%s,%s))" % tuple(keys)),
+            # A non-trivial miniscript policy embedding a multisig plus
+            # additional pk() leaves, exercising recursive derivation order.
+            (
+                "miniscript",
+                "wsh(andor(multi(2,%s,%s,%s),older(1008),pk(%s)))"
+                % tuple(keys[:4]),
+            ),
+            # Taproot with an internal key and a taptree leaf.
+            ("taproot", "tr(%s,pk(%s))" % (keys[0], keys[1])),
+        ]
+        for name, dstr in descriptors:
+            desc = Descriptor.from_string(dstr)
+            for branch_index in range(desc.num_branches):
+                derived = desc.derive(7, branch_index=branch_index)
+                self.assertEqual(
+                    len(derived.keys),
+                    len(desc.keys),
+                    "key count changed for %s branch %d" % (name, branch_index),
+                )
+                for i, (orig, drv) in enumerate(zip(desc.keys, derived.keys)):
+                    self.assertEqual(
+                        orig.derive(7, branch_index=branch_index).key.to_base58(),
+                        drv.key.to_base58(),
+                        "key %d mismatch for %s branch %d" % (i, name, branch_index),
+                    )
+
 
 # test that:
 # + str(d) == d


### PR DESCRIPTION
Downstream projects (notably [Specter-DIY](https://github.com/cryptoadvance/specter-diy)) match PSBT public keys by calling `Descriptor.derive()` and then indexing into `derived.keys` using the position of the matching key in the original descriptor's `keys` list. For example, in `src/apps/wallets/manager.py`:

```python
for key_idx, key in enumerate(wallet.descriptor.keys):
    claim = key.check_derivation(derivation)
    if claim is not None:
        idx, branch_idx = claim
        desc, _ = wallet.get_descriptor(idx, branch_idx)
        derived_pubkey = desc.keys[key_idx].get_public_key()
```

This works today because `Descriptor.derive()` and `Miniscript.derive()` preserve key-expression order, but that behavior is not documented or tested. This PR adds docstrings and a regression test so the invariant becomes part of the public API contract.

Changes:
- Document key-order preservation in `Descriptor.derive()`.
- Document key-order preservation in `Miniscript.derive()`.
- Add `test_derive_preserves_key_order` to prevent future regressions.